### PR TITLE
Go-formatting the project

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -1,13 +1,13 @@
 package common
 
 import (
-	"math/big"
-	"crypto/rand"
 	"crypto/dsa"
+	"crypto/rand"
 	"crypto/sha512"
 	"errors"
 	"io"
 	"log"
+	"math/big"
 )
 
 // It takes big.Int numbers, transform them to bytes, and concatenate the bytes.
@@ -29,8 +29,8 @@ func HashIntoBytes(numbers ...*big.Int) []byte {
 }
 
 // It concatenates numbers (their bytes), computes a hash and outputs a hash as *big.Int.
-func Hash(numbers ...*big.Int) (*big.Int) {
-	hashBytes := HashIntoBytes(numbers...)	
+func Hash(numbers ...*big.Int) *big.Int {
+	hashBytes := HashIntoBytes(numbers...)
 	hashNum := new(big.Int).SetBytes(hashBytes)
 	return hashNum
 }
@@ -39,12 +39,12 @@ func Hash(numbers ...*big.Int) (*big.Int) {
 func Exponentiate(x, y, m *big.Int) *big.Int {
 	var r *big.Int
 	if y.Cmp(big.NewInt(0)) >= 0 {
-    	r = new(big.Int).Exp(x, y, m) 
-    } else {
-    	r = new(big.Int).Exp(x, new(big.Int).Abs(y), m) 
-    	r.ModInverse(r, m)
-    }
-    return r
+		r = new(big.Int).Exp(x, y, m)
+	} else {
+		r = new(big.Int).Exp(x, new(big.Int).Abs(y), m)
+		r.ModInverse(r, m)
+	}
+	return r
 }
 
 // Computes least common multiple.
@@ -70,7 +70,7 @@ func GetRandomInt(max *big.Int) *big.Int {
 // Returns random integer from [min, max).
 func GetRandomIntFromRange(min, max *big.Int) (*big.Int, error) {
 	if min.Cmp(max) >= 0 {
-		err := errors.New("GetRandomIntFromRange: max has to be bigger than min")	
+		err := errors.New("GetRandomIntFromRange: max has to be bigger than min")
 		return nil, err
 	}
 	if min.Cmp(big.NewInt(0)) < 0 && max.Cmp(big.NewInt(0)) < 0 {
@@ -101,13 +101,13 @@ func GetRandomIntOfLength(bitLength int) *big.Int {
 	max := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(bitLength-1)), nil)
 	o := GetRandomInt(max)
 	r := new(big.Int).Add(max, o)
-	
+
 	b1 := r.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(bitLength-1)), nil))
 	b2 := r.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(bitLength)), nil))
 	if (b1 != 1) || (b2 != -1) {
 		log.Panic("parameter not properly chosen")
 	}
-	
+
 	return r
 }
 
@@ -115,7 +115,7 @@ func GetRandomIntOfLength(bitLength int) *big.Int {
 // It works only when p is prime.
 func IsQuadraticResidue(a *big.Int, p *big.Int) (bool, error) {
 	if !p.ProbablyPrime(20) {
-		err := errors.New("p is not prime")	
+		err := errors.New("p is not prime")
 		return false, err
 	}
 
@@ -123,13 +123,13 @@ func IsQuadraticResidue(a *big.Int, p *big.Int) (bool, error) {
 	p1 := new(big.Int).Sub(p, big.NewInt(1))
 	p1 = new(big.Int).Div(p1, big.NewInt(2))
 	cr := new(big.Int).Exp(a, p1, p)
-	
+
 	if cr.Cmp(big.NewInt(1)) == 0 {
 		return true, nil
 	} else if cr.Cmp(new(big.Int).Sub(p, big.NewInt(1))) == 0 {
 		return false, nil
 	} else {
-		err := errors.New("seems that p is not prime")	
+		err := errors.New("seems that p is not prime")
 		return false, err
 	}
 }
@@ -137,8 +137,8 @@ func IsQuadraticResidue(a *big.Int, p *big.Int) (bool, error) {
 // GetGeneratorOfZnSubgroup returns a generator of a subgroup of a specified order in Z_n.
 // Parameter groupOrder is order of Z_n (if n is prime, order is n-1).
 func GetGeneratorOfZnSubgroup(n, groupOrder, subgroupOrder *big.Int) (*big.Int, error) {
-	if big.NewInt(0).Mod(groupOrder, subgroupOrder).Cmp(big.NewInt(0)) != 0 { 
-		err := errors.New("subgroupOrder does not divide groupOrder")	
+	if big.NewInt(0).Mod(groupOrder, subgroupOrder).Cmp(big.NewInt(0)) != 0 {
+		err := errors.New("subgroupOrder does not divide groupOrder")
 		return nil, err
 	}
 	r := new(big.Int).Div(groupOrder, subgroupOrder)
@@ -159,7 +159,7 @@ func GetGeneratorOfCompositeQR(p, q *big.Int) (g *big.Int, err error) {
 	one := big.NewInt(1)
 	two := big.NewInt(2)
 	tmp := new(big.Int)
-	
+
 	// check if p and q are safe primes:
 	p1 := new(big.Int)
 	p1.Sub(p, one)
@@ -167,14 +167,14 @@ func GetGeneratorOfCompositeQR(p, q *big.Int) (g *big.Int, err error) {
 	q1 := new(big.Int)
 	q1.Sub(q, one)
 	q1.Div(q1, two)
-	
+
 	if p.ProbablyPrime(20) && q.ProbablyPrime(20) && p1.ProbablyPrime(20) && q1.ProbablyPrime(20) {
 	} else {
-		err := errors.New("p and q need to be safe primes")	
+		err := errors.New("p and q need to be safe primes")
 		return nil, err
 	}
-	
-	// The possible orders are 2, p1, q1, 2 * p1, 2 * q1, and 2 * p1 * q1. 
+
+	// The possible orders are 2, p1, q1, 2 * p1, 2 * q1, and 2 * p1 * q1.
 	// We need to make sure that all elements of orders smaller than 2 * p1 * q1 are ruled out.
 
 	for {
@@ -194,7 +194,7 @@ func GetGeneratorOfCompositeQR(p, q *big.Int) (g *big.Int, err error) {
 		if tmp.Cmp(one) != 0 {
 			continue
 		}
-		
+
 		// q
 		tmp.GCD(nil, nil, a, q)
 		if tmp.Cmp(one) != 0 {
@@ -208,8 +208,8 @@ func GetGeneratorOfCompositeQR(p, q *big.Int) (g *big.Int, err error) {
 		if tmp.Cmp(one) != 0 {
 			continue
 		}
-		
-		g := a.Mul(a, big.NewInt(2))	
+
+		g := a.Mul(a, big.NewInt(2))
 		return g, nil
 	}
 }
@@ -217,22 +217,22 @@ func GetGeneratorOfCompositeQR(p, q *big.Int) (g *big.Int, err error) {
 // It returns primes p and q where p = r * q + 1 for some integer r.
 func GetSchnorrGroup(qBitLength int) (*big.Int, *big.Int, *big.Int, error) {
 	// Using DSA GenerateParameters:
-	
+
 	sizes := dsa.L1024N160
-	
+
 	if qBitLength == 160 {
 		sizes = dsa.L1024N160
 	} else if qBitLength == 224 {
 		sizes = dsa.L2048N224
 	} else if qBitLength == 256 {
 		sizes = dsa.L2048N256
-	//} else if qBitLength == 256 {
-	//	sizes = dsa.L3072N256
+		//} else if qBitLength == 256 {
+		//	sizes = dsa.L3072N256
 	} else {
 		err := errors.New("generating Schnorr primes for these bitlengths is not supported")
 		return nil, nil, nil, err
 	}
-	
+
 	params := dsa.Parameters{}
 	err := dsa.GenerateParameters(&params, rand.Reader, sizes)
 	log.Println(err)
@@ -249,11 +249,11 @@ func GetSafePrime(bits int) (p *big.Int, err error) {
 	p = big.NewInt(0)
 	p.Mul(p1, big.NewInt(2))
 	p.Add(p, big.NewInt(1))
-	
+
 	if p.BitLen() == bits {
 		return p, nil
 	} else {
-		err := errors.New("bit length not correct")	
+		err := errors.New("bit length not correct")
 		return nil, err
 	}
 }
@@ -261,16 +261,16 @@ func GetSafePrime(bits int) (p *big.Int, err error) {
 // GetGermainPrime returns a prime number p for which 2*p + 1 is also prime. Note that conversely p
 // is called safe prime.
 func GetGermainPrime(bits int) (p *big.Int) {
-	// multiple germainPrime goroutines are called and we assume at least one will compute a 
+	// multiple germainPrime goroutines are called and we assume at least one will compute a
 	// safe prime and send it to the channel, thus we do not handle errors in germainPrime
 	var c chan *big.Int = make(chan *big.Int)
-	var quit chan int = make(chan int)	
+	var quit chan int = make(chan int)
 	for j := int(0); j < 8; j++ {
 		go germainPrime(bits, c, quit)
 	}
-	msg := <- c
+	msg := <-c
 	close(c)
-	close(quit)	
+	close(quit)
 	return msg
 }
 
@@ -310,12 +310,12 @@ func germainPrime(bits int, c chan *big.Int, quit chan int) (p *big.Int, err err
 
 	for {
 		select {
-	    case <- quit:
-	   		return
-	   	default:
-	   		// this is to make it non-blocking
-	    }	
-		
+		case <-quit:
+			return
+		default:
+			// this is to make it non-blocking
+		}
+
 		_, err = io.ReadFull(rand, bytes)
 		if err != nil {
 			return nil, err
@@ -355,10 +355,10 @@ func germainPrime(bits int, c chan *big.Int, quit chan int) (p *big.Int, err err
 				if m%uint64(prime) == 0 && (bits > 6 || m != uint64(prime)) {
 					continue NextDelta
 				}
-				
+
 				// 2*mod + 2*delta + 1	should not be divisible by smallPrimes as well
 				m1 := (2*m + 1) % smallPrimesProduct.Uint64()
-				
+
 				if m1%uint64(prime) == 0 && (bits > 6 || m1 != uint64(prime)) {
 					continue NextDelta
 				}
@@ -366,9 +366,9 @@ func germainPrime(bits int, c chan *big.Int, quit chan int) (p *big.Int, err err
 
 			if delta > 0 {
 				bigMod.SetUint64(delta)
-				p.Add(p, bigMod)				
+				p.Add(p, bigMod)
 			}
-			
+
 			p1.Add(p, p)
 			p1.Add(p1, big.NewInt(1))
 			break
@@ -385,16 +385,15 @@ func germainPrime(bits int, c chan *big.Int, quit chan int) (p *big.Int, err err
 				// otherwise it this goroutine might be searching for a germain
 				// prime for some time after one was found by another goroutine
 				select {
-				case <- quit:
-			   		return
-			   	default:
-			   		// this is to make it non-blocking
-			    }
-				
+				case <-quit:
+					return
+				default:
+					// this is to make it non-blocking
+				}
+
 				c <- p
 				return
 			}
 		}
 	}
 }
-

--- a/common/polynomials.go
+++ b/common/polynomials.go
@@ -8,8 +8,8 @@ import (
 // polynomial is p(x) = a_0 + a_1 * x + ... + a_degree * x^degree
 type Polynomial struct {
 	coefficients []*big.Int
-	degree int
-	prime *big.Int // coefficients are in Z_prime
+	degree       int
+	prime        *big.Int // coefficients are in Z_prime
 }
 
 func NewRandomPolynomial(degree int, prime *big.Int) (*Polynomial, error) {
@@ -18,12 +18,12 @@ func NewRandomPolynomial(degree int, prime *big.Int) (*Polynomial, error) {
 		coef := GetRandomInt(prime) // coeff has to be < prime
 		coefficients = append(coefficients, coef)
 	}
-	polynomial := Polynomial {
+	polynomial := Polynomial{
 		coefficients: coefficients,
-		degree: degree,
-		prime: prime,
+		degree:       degree,
+		prime:        prime,
 	}
-	
+
 	return &polynomial, nil
 }
 
@@ -32,7 +32,7 @@ func (polynomial *Polynomial) SetCoefficient(coeff_ind int, coefficient *big.Int
 }
 
 // Computes polynomial values at given points.
-func (polynomial *Polynomial) GetValues(points []*big.Int) (map[*big.Int]*big.Int) {
+func (polynomial *Polynomial) GetValues(points []*big.Int) map[*big.Int]*big.Int {
 	m := make(map[*big.Int]*big.Int)
 	for _, value := range points {
 		m[value] = polynomial.GetValue(value)
@@ -41,7 +41,7 @@ func (polynomial *Polynomial) GetValues(points []*big.Int) (map[*big.Int]*big.In
 }
 
 // Computes polynomial values at given point.
-func (polynomial *Polynomial) GetValue(point *big.Int) (*big.Int) {
+func (polynomial *Polynomial) GetValue(point *big.Int) *big.Int {
 	value := big.NewInt(0)
 	for i, coeff := range polynomial.coefficients {
 		// a_i * point^i
@@ -54,21 +54,21 @@ func (polynomial *Polynomial) GetValue(point *big.Int) (*big.Int) {
 }
 
 // Given degree+1 points which are on the polynomial, LagrangeInterpolation computes p(a).
-func LagrangeInterpolation(a *big.Int, points map[*big.Int]*big.Int, prime *big.Int) (*big.Int) {
+func LagrangeInterpolation(a *big.Int, points map[*big.Int]*big.Int, prime *big.Int) *big.Int {
 	value := big.NewInt(0)
 	for key, val := range points {
 		numerator := big.NewInt(1)
 		denominator := big.NewInt(1)
 		t := new(big.Int)
-		for key1, _ := range points {
+		for key1 := range points {
 			if key == key1 {
 				continue
 			}
-			
+
 			t.Sub(a, key1)
 			numerator.Mul(numerator, t)
 			numerator.Mod(numerator, prime)
-			
+
 			t.Sub(key, key1)
 			denominator.Mul(denominator, t)
 			denominator.Mod(denominator, prime)
@@ -78,23 +78,16 @@ func LagrangeInterpolation(a *big.Int, points map[*big.Int]*big.Int, prime *big.
 		denominator_inv.ModInverse(denominator, prime)
 		t1.Mul(numerator, denominator_inv)
 		t1.Mod(t1, prime)
-		
+
 		t2 := new(big.Int)
 		// (prime + value + t1 * val) % prime
 		t2.Mul(val, t1)
 		t2.Add(t2, prime)
 		t2.Add(t2, prime)
-		
+
 		value.Add(value, t2)
 		value.Add(value, prime)
 	}
 	value.Mod(value, prime)
 	return value
 }
-
-
-
-
-
-
-

--- a/common/storage.go
+++ b/common/storage.go
@@ -1,36 +1,32 @@
 package common
 
 import (
-	"os"
 	"io/ioutil"
+	"os"
 )
 
 func Store(content []byte, path string) error {
 	f, err := os.Create(path)
-    if err != nil {
-        return err
-    }	
+	if err != nil {
+		return err
+	}
 	defer f.Close()
-	
-    err = ioutil.WriteFile(path, content, 0644)
-    f.Write(content)
-    
-    if err != nil {
-        return err
-    }	
-    
-    return nil
+
+	err = ioutil.WriteFile(path, content, 0644)
+	f.Write(content)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func Load(path string) ([]byte, error) {
-    bytes, err := ioutil.ReadFile(path)
-    if err != nil {
-        return nil, err
-    }	
-    
-    return bytes, nil
+	bytes, err := ioutil.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return bytes, nil
 }
-
-
-
-

--- a/dlog/ecdlog.go
+++ b/dlog/ecdlog.go
@@ -1,19 +1,19 @@
 package dlog
 
 import (
-    "math/big"
 	"crypto/elliptic"
+	"math/big"
 )
 
 type ECDLog struct {
-	Curve elliptic.Curve
-	OrderOfSubgroup *big.Int	
+	Curve           elliptic.Curve
+	OrderOfSubgroup *big.Int
 }
 
-func NewECDLog() (*ECDLog) {
+func NewECDLog() *ECDLog {
 	p224 := elliptic.P224()
-	ecdlog := ECDLog {
-		Curve: p224,
+	ecdlog := ECDLog{
+		Curve:           p224,
 		OrderOfSubgroup: p224.Params().N, // order of G
 	}
 	return &ecdlog
@@ -21,13 +21,13 @@ func NewECDLog() (*ECDLog) {
 
 //func (dlog *ECDLog) Multiply(x1, y1, x2, y2 *big.Int) (*big.Int, *big.Int) {
 func (dlog *ECDLog) Multiply(params ...*big.Int) (*big.Int, *big.Int) {
-	x1 := params[0]	
-	y1 := params[1]	
-	x2 := params[2]	
-	y2 := params[3]	
-	
+	x1 := params[0]
+	y1 := params[1]
+	x2 := params[2]
+	y2 := params[3]
+
 	// calculates (x1, y1) + (x2, y2) as we use elliptic curves
-	x, y := dlog.Curve.Add(x1, y1, x2, y2)	
+	x, y := dlog.Curve.Add(x1, y1, x2, y2)
 	return x, y
 }
 
@@ -38,20 +38,16 @@ func (dlog *ECDLog) Exponentiate(params ...*big.Int) (*big.Int, *big.Int) {
 	exponent := params[2]
 
 	// calculates (x, y) * exponent
-	hx, hy := dlog.Curve.ScalarMult(x, y, exponent.Bytes())	
+	hx, hy := dlog.Curve.ScalarMult(x, y, exponent.Bytes())
 	return hx, hy
 }
 
 func (dlog *ECDLog) ExponentiateBaseG(exponent *big.Int) (*big.Int, *big.Int) {
 	// calculates g ^^ exponent or better to say g * exponent as this is elliptic ((gx, gy) * exponent)
-	hx, hy := dlog.Curve.ScalarBaseMult(exponent.Bytes())	
+	hx, hy := dlog.Curve.ScalarBaseMult(exponent.Bytes())
 	return hx, hy
 }
 
 func (dlog *ECDLog) GetOrderOfSubgroup() *big.Int {
 	return dlog.OrderOfSubgroup
 }
-
-
-
-

--- a/dlog/zp_dlog.go
+++ b/dlog/zp_dlog.go
@@ -1,16 +1,16 @@
 package dlog
 
 import (
-    "math/big"
-    "github.com/xlab-si/emmy/common"
+	"github.com/xlab-si/emmy/common"
+	"math/big"
 )
 
 // TODO: doesn't look like having the same interface for zp_dlog and ecdlog is a good idea; refactor
 
 type ZpDLog struct {
-    P *big.Int // modulus of the group
-    G *big.Int // generator of subgroup
-    OrderOfSubgroup *big.Int // order of subgroup
+	P               *big.Int // modulus of the group
+	G               *big.Int // generator of subgroup
+	OrderOfSubgroup *big.Int // order of subgroup
 }
 
 func NewZpSchnorr(qBitLength int) (*ZpDLog, error) {
@@ -24,25 +24,25 @@ func NewZpSchnorr(qBitLength int) (*ZpDLog, error) {
 
 func NewZpSafePrime(modulusBitLength int) (*ZpDLog, error) {
 	p, err := common.GetSafePrime(modulusBitLength)
-    if err != nil {
+	if err != nil {
 		return nil, err
-    }
-    pMin := new(big.Int)
-    pMin.Sub(p, big.NewInt(1))
-    q := new(big.Int).Div(pMin, big.NewInt(2))
-    
-    g, err := common.GetGeneratorOfZnSubgroup(p, pMin, q)
+	}
+	pMin := new(big.Int)
+	pMin.Sub(p, big.NewInt(1))
+	q := new(big.Int).Div(pMin, big.NewInt(2))
+
+	g, err := common.GetGeneratorOfZnSubgroup(p, pMin, q)
 	if err != nil {
 		return nil, err
 	}
 
-    zpSafePrime := ZpDLog {
-		P: p,
-		G: g,
+	zpSafePrime := ZpDLog{
+		P:               p,
+		G:               g,
 		OrderOfSubgroup: q,
-    }
+	}
 
-    return &zpSafePrime, nil
+	return &zpSafePrime, nil
 }
 
 // Multiply multiplies two elements from Z_p. Note that two values are returned
@@ -52,14 +52,14 @@ func NewZpSafePrime(modulusBitLength int) (*ZpDLog, error) {
 func (dlog ZpDLog) Multiply(params ...*big.Int) (*big.Int, *big.Int) {
 	x := params[0]
 	y := params[1]
-	
+
 	r := new(big.Int)
 	r.Mul(x, y)
 	r.Mod(r, dlog.P)
-	
-	// returning two values (second as nil) to make it implement the DLog interface sucks, 
+
+	// returning two values (second as nil) to make it implement the DLog interface sucks,
 	// but other options seem even worse
-  	return r, nil 
+	return r, nil
 }
 
 //func (dlog *ZpDLog) Exponentiate(x, exponent *big.Int) *big.Int {
@@ -68,22 +68,16 @@ func (dlog ZpDLog) Exponentiate(params ...*big.Int) (*big.Int, *big.Int) {
 	exponent := params[1]
 
 	r := new(big.Int)
-  	r.Exp(x, exponent, dlog.P)
-  	return r, nil
+	r.Exp(x, exponent, dlog.P)
+	return r, nil
 }
 
 func (dlog ZpDLog) ExponentiateBaseG(exponent *big.Int) (*big.Int, *big.Int) {
 	x := new(big.Int)
-  	x.Exp(dlog.G, exponent, dlog.P)
-  	return x, nil
+	x.Exp(dlog.G, exponent, dlog.P)
+	return x, nil
 }
 
 func (dlog ZpDLog) GetOrderOfSubgroup() *big.Int {
 	return dlog.OrderOfSubgroup
 }
-
-
-
-
-
-

--- a/dlogproofs/dlog_equality.go
+++ b/dlogproofs/dlog_equality.go
@@ -1,9 +1,9 @@
 package dlogproofs
 
 import (
-	"math/big"
 	"github.com/xlab-si/emmy/common"
 	"github.com/xlab-si/emmy/dlog"
+	"math/big"
 )
 
 func RunDLogEquality(secret, g1, g2, t1, t2 *big.Int, dlog *dlog.ZpDLog) bool {
@@ -20,24 +20,24 @@ func RunDLogEquality(secret, g1, g2, t1, t2 *big.Int, dlog *dlog.ZpDLog) bool {
 }
 
 type DLogEqualityProver struct {
-	DLog *dlog.ZpDLog
-	r *big.Int
+	DLog   *dlog.ZpDLog
+	r      *big.Int
 	secret *big.Int
-	g1 *big.Int
-	g2 *big.Int
+	g1     *big.Int
+	g2     *big.Int
 }
 
-func NewDLogEqualityProver(dlog *dlog.ZpDLog) (*DLogEqualityProver) {
-	prover := DLogEqualityProver {
+func NewDLogEqualityProver(dlog *dlog.ZpDLog) *DLogEqualityProver {
+	prover := DLogEqualityProver{
 		DLog: dlog,
 	}
-	
-    return &prover
+
+	return &prover
 }
 
 func (prover *DLogEqualityProver) GetProofRandomData(secret, g1, g2 *big.Int) (*big.Int, *big.Int) {
 	// Sets the values that are needed before the protocol can be run.
-	// The protocol proves the knowledge of log_g1(t1), log_g2(t2) and 
+	// The protocol proves the knowledge of log_g1(t1), log_g2(t2) and
 	// that log_g1(t1) = log_g2(t2).
 	prover.secret = secret
 	prover.g1 = g1
@@ -45,12 +45,12 @@ func (prover *DLogEqualityProver) GetProofRandomData(secret, g1, g2 *big.Int) (*
 
 	r := common.GetRandomInt(prover.DLog.GetOrderOfSubgroup())
 	prover.r = r
-    x1, _ := prover.DLog.Exponentiate(prover.g1, r)	
-    x2, _ := prover.DLog.Exponentiate(prover.g2, r)	
+	x1, _ := prover.DLog.Exponentiate(prover.g1, r)
+	x2, _ := prover.DLog.Exponentiate(prover.g2, r)
 	return x1, x2
 }
 
-func (prover *DLogEqualityProver) GetProofData(challenge *big.Int) (*big.Int) {
+func (prover *DLogEqualityProver) GetProofData(challenge *big.Int) *big.Int {
 	// z = r + challenge * secret
 	z := new(big.Int)
 	z.Mul(challenge, prover.secret)
@@ -59,29 +59,28 @@ func (prover *DLogEqualityProver) GetProofData(challenge *big.Int) (*big.Int) {
 	return z
 }
 
-
 type DLogEqualityVerifier struct {
-	DLog *dlog.ZpDLog
+	DLog      *dlog.ZpDLog
 	challenge *big.Int
-	g1 *big.Int
-	g2 *big.Int
-	x1 *big.Int
-	x2 *big.Int
-	t1 *big.Int
-	t2 *big.Int
+	g1        *big.Int
+	g2        *big.Int
+	x1        *big.Int
+	x2        *big.Int
+	t1        *big.Int
+	t2        *big.Int
 }
 
-func NewDLogEqualityVerifier(dlog *dlog.ZpDLog) (*DLogEqualityVerifier) {	
-	verifier := DLogEqualityVerifier {
+func NewDLogEqualityVerifier(dlog *dlog.ZpDLog) *DLogEqualityVerifier {
+	verifier := DLogEqualityVerifier{
 		DLog: dlog,
 	}
-	
-    return &verifier
+
+	return &verifier
 }
 
-func (verifier *DLogEqualityVerifier) GetChallenge(g1, g2, t1, t2, x1, x2 *big.Int) (*big.Int) {
+func (verifier *DLogEqualityVerifier) GetChallenge(g1, g2, t1, t2, x1, x2 *big.Int) *big.Int {
 	// Set the values that are needed before the protocol can be run.
-	// The protocol proves the knowledge of log_g1(t1), log_g2(t2) and 
+	// The protocol proves the knowledge of log_g1(t1), log_g2(t2) and
 	// that log_g1(t1) = log_g2(t2).
 	verifier.g1 = g1
 	verifier.g2 = g2
@@ -93,29 +92,24 @@ func (verifier *DLogEqualityVerifier) GetChallenge(g1, g2, t1, t2, x1, x2 *big.I
 	verifier.x2 = x2
 
 	challenge := common.GetRandomInt(verifier.DLog.GetOrderOfSubgroup())
-    verifier.challenge = challenge
-    return challenge
+	verifier.challenge = challenge
+	return challenge
 }
 
-// It receives z = r + secret * challenge. 
+// It receives z = r + secret * challenge.
 //It returns true if g1^z = g1^r * (g1^secret) ^ challenge and g2^z = g2^r * (g2^secret) ^ challenge.
-func (verifier *DLogEqualityVerifier) Verify(z *big.Int) (bool) {
-	left1, _ := verifier.DLog.Exponentiate(verifier.g1, z)	
-	left2, _ := verifier.DLog.Exponentiate(verifier.g2, z)	
+func (verifier *DLogEqualityVerifier) Verify(z *big.Int) bool {
+	left1, _ := verifier.DLog.Exponentiate(verifier.g1, z)
+	left2, _ := verifier.DLog.Exponentiate(verifier.g2, z)
 
-    r11, _ := verifier.DLog.Exponentiate(verifier.t1, verifier.challenge)	
-    r12, _ := verifier.DLog.Exponentiate(verifier.t2, verifier.challenge)	
-    right1, _ := verifier.DLog.Multiply(r11, verifier.x1)	
-    right2, _ := verifier.DLog.Multiply(r12, verifier.x2)	
-	
+	r11, _ := verifier.DLog.Exponentiate(verifier.t1, verifier.challenge)
+	r12, _ := verifier.DLog.Exponentiate(verifier.t2, verifier.challenge)
+	right1, _ := verifier.DLog.Multiply(r11, verifier.x1)
+	right2, _ := verifier.DLog.Multiply(r12, verifier.x2)
+
 	if left1.Cmp(right1) == 0 && left2.Cmp(right2) == 0 {
 		return true
 	} else {
 		return false
 	}
 }
-
-
-
-
-

--- a/dlogproofs/dlog_equality_blinded_transcript.go
+++ b/dlogproofs/dlog_equality_blinded_transcript.go
@@ -1,9 +1,9 @@
 package dlogproofs
 
 import (
-	"math/big"
 	"github.com/xlab-si/emmy/common"
 	"github.com/xlab-si/emmy/dlog"
+	"math/big"
 )
 
 // Verifies that the blinded transcript is valid. That means the knowledge of log_g1(t1), log_G2(T2)
@@ -17,38 +17,38 @@ func VerifyBlindedTranscript(transcript []*big.Int, dlog *dlog.ZpDLog, g1, t1, G
 	left1, _ := dlog.Exponentiate(g1, transcript[3])
 	right1, _ := dlog.Exponentiate(t1, transcript[2])
 	right1, _ = dlog.Multiply(transcript[0], right1)
-	
+
 	left2, _ := dlog.Exponentiate(G2, transcript[3])
 	right2, _ := dlog.Exponentiate(T2, transcript[2])
 	right2, _ = dlog.Multiply(transcript[1], right2)
-		
-	if (left1.Cmp(right1) == 0 && left2.Cmp(right2) == 0) {
-		return true	
+
+	if left1.Cmp(right1) == 0 && left2.Cmp(right2) == 0 {
+		return true
 	} else {
-		return false	
+		return false
 	}
 }
 
 type DLogEqualityBTranscriptProver struct {
-	DLog *dlog.ZpDLog
-	r *big.Int
+	DLog   *dlog.ZpDLog
+	r      *big.Int
 	secret *big.Int
-	g1 *big.Int
-	g2 *big.Int
+	g1     *big.Int
+	g2     *big.Int
 }
 
-func NewDLogEqualityBTranscriptProver(dlog *dlog.ZpDLog) (*DLogEqualityBTranscriptProver) {
-	prover := DLogEqualityBTranscriptProver {
+func NewDLogEqualityBTranscriptProver(dlog *dlog.ZpDLog) *DLogEqualityBTranscriptProver {
+	prover := DLogEqualityBTranscriptProver{
 		DLog: dlog,
 	}
-    return &prover
+	return &prover
 }
 
 // Prove that you know dlog_g1(h1), dlog_g2(h2) and that dlog_g1(h1) = dlog_g2(h2).
-func (prover *DLogEqualityBTranscriptProver) GetProofRandomData(secret, g1, g2 *big.Int) (*big.Int, 
-		*big.Int) {
+func (prover *DLogEqualityBTranscriptProver) GetProofRandomData(secret, g1, g2 *big.Int) (*big.Int,
+	*big.Int) {
 	// Set the values that are needed before the protocol can be run.
-	// The protocol proves the knowledge of log_g1(t1), log_g2(t2) and 
+	// The protocol proves the knowledge of log_g1(t1), log_g2(t2) and
 	// that log_g1(t1) = log_g2(t2).
 	prover.secret = secret
 	prover.g1 = g1
@@ -56,12 +56,12 @@ func (prover *DLogEqualityBTranscriptProver) GetProofRandomData(secret, g1, g2 *
 
 	r := common.GetRandomInt(prover.DLog.GetOrderOfSubgroup())
 	prover.r = r
-    x1, _ := prover.DLog.Exponentiate(prover.g1, r)	
-    x2, _ := prover.DLog.Exponentiate(prover.g2, r)	
+	x1, _ := prover.DLog.Exponentiate(prover.g1, r)
+	x2, _ := prover.DLog.Exponentiate(prover.g2, r)
 	return x1, x2
 }
 
-func (prover *DLogEqualityBTranscriptProver) GetProofData(challenge *big.Int) (*big.Int) {
+func (prover *DLogEqualityBTranscriptProver) GetProofData(challenge *big.Int) *big.Int {
 	// z = r + challenge * secret
 	z := new(big.Int)
 	z.Mul(challenge, prover.secret)
@@ -71,35 +71,35 @@ func (prover *DLogEqualityBTranscriptProver) GetProofData(challenge *big.Int) (*
 }
 
 type DLogEqualityBTranscriptVerifier struct {
-	DLog *dlog.ZpDLog
-	gamma *big.Int
-	challenge *big.Int
-	g1 *big.Int
-	g2 *big.Int
-	x1 *big.Int
-	x2 *big.Int
-	t1 *big.Int
-	t2 *big.Int
+	DLog       *dlog.ZpDLog
+	gamma      *big.Int
+	challenge  *big.Int
+	g1         *big.Int
+	g2         *big.Int
+	x1         *big.Int
+	x2         *big.Int
+	t1         *big.Int
+	t2         *big.Int
 	transcript []*big.Int
-	alpha *big.Int
+	alpha      *big.Int
 }
 
-func NewDLogEqualityBTranscriptVerifier(dlog *dlog.ZpDLog, 
-		gamma *big.Int) *DLogEqualityBTranscriptVerifier {
+func NewDLogEqualityBTranscriptVerifier(dlog *dlog.ZpDLog,
+	gamma *big.Int) *DLogEqualityBTranscriptVerifier {
 	if gamma == nil {
 		gamma = common.GetRandomInt(dlog.GetOrderOfSubgroup())
 	}
-	verifier := DLogEqualityBTranscriptVerifier {
-		DLog: dlog,
+	verifier := DLogEqualityBTranscriptVerifier{
+		DLog:  dlog,
 		gamma: gamma,
 	}
-	
-    return &verifier
+
+	return &verifier
 }
 
-func (verifier *DLogEqualityBTranscriptVerifier) GetChallenge(g1, g2, t1, t2, x1, x2 *big.Int) (*big.Int) {
+func (verifier *DLogEqualityBTranscriptVerifier) GetChallenge(g1, g2, t1, t2, x1, x2 *big.Int) *big.Int {
 	// Set the values that are needed before the protocol can be run.
-	// The protocol proves the knowledge of log_g1(t1), log_g2(t2) and 
+	// The protocol proves the knowledge of log_g1(t1), log_g2(t2) and
 	// that log_g1(t1) = log_g2(t2).
 	verifier.g1 = g1
 	verifier.g2 = g2
@@ -112,62 +112,59 @@ func (verifier *DLogEqualityBTranscriptVerifier) GetChallenge(g1, g2, t1, t2, x1
 
 	alpha := common.GetRandomInt(verifier.DLog.GetOrderOfSubgroup())
 	beta := common.GetRandomInt(verifier.DLog.GetOrderOfSubgroup())
-	
+
 	// alpha1 = g1^r * g1^alpha * t1^beta
 	// beta1 = (g2^r * g2^alpha * t2^beta)^gamma
 	alpha1, _ := verifier.DLog.Exponentiate(verifier.g1, alpha)
 	alpha1, _ = verifier.DLog.Multiply(verifier.x1, alpha1)
 	tmp, _ := verifier.DLog.Exponentiate(verifier.t1, beta)
 	alpha1, _ = verifier.DLog.Multiply(alpha1, tmp)
-	
+
 	beta1, _ := verifier.DLog.Exponentiate(verifier.g2, alpha)
 	beta1, _ = verifier.DLog.Multiply(verifier.x2, beta1)
 	tmp, _ = verifier.DLog.Exponentiate(verifier.t2, beta)
 	beta1, _ = verifier.DLog.Multiply(beta1, tmp)
 	beta1, _ = verifier.DLog.Exponentiate(beta1, verifier.gamma)
-	
+
 	// c = hash(alpha1, beta) + beta mod q
 	hashNum := common.Hash(alpha1, beta1)
 	challenge := new(big.Int).Add(hashNum, beta)
 	challenge.Mod(challenge, verifier.DLog.OrderOfSubgroup)
-    verifier.challenge = challenge
+	verifier.challenge = challenge
 
-    var transcript []*big.Int
-    transcript = append(transcript, alpha1)
-    transcript = append(transcript, beta1)
-    transcript = append(transcript, hashNum)
-    verifier.transcript = transcript
-    verifier.alpha = alpha
+	var transcript []*big.Int
+	transcript = append(transcript, alpha1)
+	transcript = append(transcript, beta1)
+	transcript = append(transcript, hashNum)
+	verifier.transcript = transcript
+	verifier.alpha = alpha
 
-    return challenge
+	return challenge
 }
 
-// It receives z = r + secret * challenge. 
+// It receives z = r + secret * challenge.
 //It returns true if g1^z = g1^r * (g1^secret) ^ challenge and g2^z = g2^r * (g2^secret) ^ challenge.
-func (verifier *DLogEqualityBTranscriptVerifier) Verify(z *big.Int) (bool, []*big.Int, 
-		*big.Int, *big.Int) {
-	left1, _ := verifier.DLog.Exponentiate(verifier.g1, z)	
-	left2, _ := verifier.DLog.Exponentiate(verifier.g2, z)	
+func (verifier *DLogEqualityBTranscriptVerifier) Verify(z *big.Int) (bool, []*big.Int,
+	*big.Int, *big.Int) {
+	left1, _ := verifier.DLog.Exponentiate(verifier.g1, z)
+	left2, _ := verifier.DLog.Exponentiate(verifier.g2, z)
 
-    r11, _ := verifier.DLog.Exponentiate(verifier.t1, verifier.challenge)	
-    r12, _ := verifier.DLog.Exponentiate(verifier.t2, verifier.challenge)	
-    right1, _ := verifier.DLog.Multiply(r11, verifier.x1)	
-    right2, _ := verifier.DLog.Multiply(r12, verifier.x2)	
+	r11, _ := verifier.DLog.Exponentiate(verifier.t1, verifier.challenge)
+	r12, _ := verifier.DLog.Exponentiate(verifier.t2, verifier.challenge)
+	right1, _ := verifier.DLog.Multiply(r11, verifier.x1)
+	right2, _ := verifier.DLog.Multiply(r12, verifier.x2)
 
 	// transcript [(alpha1, beta1), hash(alpha1, beta1), z+alpha]
 	// however, we are actually returning [alpha1, beta1, hash(alpha1, beta1), z+alpha]
 	z1 := new(big.Int).Add(z, verifier.alpha)
 	verifier.transcript = append(verifier.transcript, z1)
-	
+
 	G2, _ := verifier.DLog.Exponentiate(verifier.g2, verifier.gamma)
 	T2, _ := verifier.DLog.Exponentiate(verifier.t2, verifier.gamma)
-	
+
 	if left1.Cmp(right1) == 0 && left2.Cmp(right2) == 0 {
 		return true, verifier.transcript, G2, T2
 	} else {
 		return false, nil, nil, nil
-	}	
+	}
 }
-
-
-

--- a/encryption/cspaillier.go
+++ b/encryption/cspaillier.go
@@ -1,13 +1,13 @@
 package encryption
 
 import (
-	"math/big"
 	"errors"
+	"github.com/golang/protobuf/proto"
+	pb "github.com/xlab-si/emmy/comm/pro"
 	"github.com/xlab-si/emmy/common"
 	"github.com/xlab-si/emmy/dlog"
-	pb "github.com/xlab-si/emmy/comm/pro"
-	"github.com/golang/protobuf/proto"
 	"log"
+	"math/big"
 )
 
 // todo: does hash really need to be into [0, 2^l]?
@@ -16,72 +16,72 @@ import (
 // Camenisch-Shoup variant of Paillier to make it (Paillier) CCA2 secure
 type CSPaillier struct {
 	SecParams *CSPaillierSecParams
-	n1 *big.Int // n'
-	PubKey *CSPaillierPubKey
+	n1        *big.Int // n'
+	PubKey    *CSPaillierPubKey
 	SecretKey *CSPaillierSecretKey
 	// verifierRandomData: encryptor stores s, r1, s1, m1;
 	verifierRandomData *CSPaillierVerifierRandomData
 	// proverRandomData stores c, u1, e1, v1, delta1, l1
 	proverRandomData *CSPaillierProverRandomData
-	proverEncData *CSPaillierProverEncData
-	verifierEncData *CSPaillierVerifierEncData
+	proverEncData    *CSPaillierProverEncData
+	verifierEncData  *CSPaillierVerifierEncData
 }
 
 type CSPaillierSecParams struct {
-	L int // length of p1 and q1 (l in a paper)
+	L        int // length of p1 and q1 (l in a paper)
 	RoLength int // ro is order of cyclic group Gamma (used for discrete logarithm)
-	K int // k in a paper; it must hold 2**K < min{p1, q1, ro}
-	K1 int // k' in a paper; it must hold ro * 2**(K + K1 + 3) < n
+	K        int // k in a paper; it must hold 2**K < min{p1, q1, ro}
+	K1       int // k' in a paper; it must hold ro * 2**(K + K1 + 3) < n
 	// lambda *big.Int // security parameters are function of lambda in a paper
 }
 
 type CSPaillierSecretKey struct {
-	N *big.Int
-	G *big.Int
+	N  *big.Int
+	G  *big.Int
 	X1 *big.Int
 	X2 *big.Int
 	X3 *big.Int
 	// the parameters below are for verifiable encryption
-	Gamma *dlog.ZpDLog // for discrete logarithm
-	VerifiableEncGroupN *big.Int
+	Gamma                *dlog.ZpDLog // for discrete logarithm
+	VerifiableEncGroupN  *big.Int
 	VerifiableEncGroupG1 *big.Int
 	VerifiableEncGroupH1 *big.Int
-	K int
-	K1 int
+	K                    int
+	K1                   int
 }
 
-// CSPaillierPubKey currently does not use auxilary parameters/primes - no additional n, p, q parameters 
+// CSPaillierPubKey currently does not use auxilary parameters/primes - no additional n, p, q parameters
 // (as specified in a paper, original n, p, q can be used).
 type CSPaillierPubKey struct {
-	N *big.Int
-	G *big.Int
+	N  *big.Int
+	G  *big.Int
 	Y1 *big.Int
 	Y2 *big.Int
 	Y3 *big.Int
 	// the parameters below are for verifiable encryption
-	Gamma *dlog.ZpDLog // for discrete logarithm
-	VerifiableEncGroupN *big.Int
+	Gamma                *dlog.ZpDLog // for discrete logarithm
+	VerifiableEncGroupN  *big.Int
 	VerifiableEncGroupG1 *big.Int
 	VerifiableEncGroupH1 *big.Int
-	K int
-	K1 int
+	K                    int
+	K1                   int
 }
 
 type CSPaillierProverRandomData struct {
-	S *big.Int
+	S  *big.Int
 	R1 *big.Int
 	S1 *big.Int
 	M1 *big.Int
 }
 
 type CSPaillierVerifierRandomData struct {
-	L *big.Int
-	U1 *big.Int
-	E1 *big.Int
-	V1 *big.Int
+	L      *big.Int
+	U1     *big.Int
+	E1     *big.Int
+	V1     *big.Int
 	Delta1 *big.Int
-	L1 *big.Int
-	C *big.Int
+	L1     *big.Int
+	C      *big.Int
 }
 
 type CSPaillierProverEncData struct {
@@ -90,22 +90,22 @@ type CSPaillierProverEncData struct {
 }
 
 type CSPaillierVerifierEncData struct {
-	U *big.Int
-	E *big.Int
-	V *big.Int
+	U     *big.Int
+	E     *big.Int
+	V     *big.Int
 	Label *big.Int
 	Delta *big.Int
 }
 
-func NewCSPaillier(secParams *CSPaillierSecParams) (*CSPaillier) {
+func NewCSPaillier(secParams *CSPaillierSecParams) *CSPaillier {
 	var cspaillier CSPaillier
 
-	cspaillier = CSPaillier {
+	cspaillier = CSPaillier{
 		SecParams: secParams,
 	}
 	cspaillier.generateKey()
-	
-    return &cspaillier
+
+	return &cspaillier
 }
 
 func NewCSPaillierFromSecKey(path string) (*CSPaillier, error) {
@@ -118,47 +118,47 @@ func NewCSPaillierFromSecKey(path string) (*CSPaillier, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	gamma := dlog.ZpDLog{
-		P: new(big.Int).SetBytes(sKey.DLogP),
-		G: new(big.Int).SetBytes(sKey.DLogG),
+		P:               new(big.Int).SetBytes(sKey.DLogP),
+		G:               new(big.Int).SetBytes(sKey.DLogG),
 		OrderOfSubgroup: new(big.Int).SetBytes(sKey.DLogQ),
 	}
 	secKey := CSPaillierSecretKey{
-		N: new(big.Int).SetBytes(sKey.N),
-		G: new(big.Int).SetBytes(sKey.G),
-		X1: new(big.Int).SetBytes(sKey.X1),
-		X2: new(big.Int).SetBytes(sKey.X2),
-		X3: new(big.Int).SetBytes(sKey.X3),
-		Gamma: &gamma,
-		VerifiableEncGroupN: new(big.Int).SetBytes(sKey.VerifiableEncGroupN),
+		N:                    new(big.Int).SetBytes(sKey.N),
+		G:                    new(big.Int).SetBytes(sKey.G),
+		X1:                   new(big.Int).SetBytes(sKey.X1),
+		X2:                   new(big.Int).SetBytes(sKey.X2),
+		X3:                   new(big.Int).SetBytes(sKey.X3),
+		Gamma:                &gamma,
+		VerifiableEncGroupN:  new(big.Int).SetBytes(sKey.VerifiableEncGroupN),
 		VerifiableEncGroupG1: new(big.Int).SetBytes(sKey.VerifiableEncGroupG1),
 		VerifiableEncGroupH1: new(big.Int).SetBytes(sKey.VerifiableEncGroupH1),
-		K: int(sKey.K),
-		K1: int(sKey.K1),
+		K:                    int(sKey.K),
+		K1:                   int(sKey.K1),
 	}
 
 	var cspaillier CSPaillier
-	cspaillier = CSPaillier {
-		SecretKey: &secKey,	
+	cspaillier = CSPaillier{
+		SecretKey: &secKey,
 	}
-	
-	pKey := &CSPaillierPubKey {
+
+	pKey := &CSPaillierPubKey{
 		N: secKey.N,
 	}
 	cspaillier.PubKey = pKey // Abs is used also in decrypt where PubKey is called
-	
-    return &cspaillier, nil
+
+	return &cspaillier, nil
 }
 
-func NewCSPaillierFromPubKey(pubKey *CSPaillierPubKey) (*CSPaillier) {
+func NewCSPaillierFromPubKey(pubKey *CSPaillierPubKey) *CSPaillier {
 	var cspaillier CSPaillier
 
-	cspaillier = CSPaillier {
+	cspaillier = CSPaillier{
 		PubKey: pubKey,
 	}
-	
-    return &cspaillier
+
+	return &cspaillier
 }
 
 func NewCSPaillierFromPubKeyFile(path string) (*CSPaillier, error) {
@@ -171,125 +171,125 @@ func NewCSPaillierFromPubKeyFile(path string) (*CSPaillier, error) {
 	if err != nil {
 		return nil, err
 	}
-	
+
 	gamma := dlog.ZpDLog{
-		P: new(big.Int).SetBytes(pKey.DLogP),
-		G: new(big.Int).SetBytes(pKey.DLogG),
+		P:               new(big.Int).SetBytes(pKey.DLogP),
+		G:               new(big.Int).SetBytes(pKey.DLogG),
 		OrderOfSubgroup: new(big.Int).SetBytes(pKey.DLogQ),
 	}
 	pubKey := CSPaillierPubKey{
-		N: new(big.Int).SetBytes(pKey.N),
-		G: new(big.Int).SetBytes(pKey.G),
-		Y1: new(big.Int).SetBytes(pKey.Y1),
-		Y2: new(big.Int).SetBytes(pKey.Y2),
-		Y3: new(big.Int).SetBytes(pKey.Y3),
-		Gamma: &gamma,
-		VerifiableEncGroupN: new(big.Int).SetBytes(pKey.VerifiableEncGroupN),
+		N:                    new(big.Int).SetBytes(pKey.N),
+		G:                    new(big.Int).SetBytes(pKey.G),
+		Y1:                   new(big.Int).SetBytes(pKey.Y1),
+		Y2:                   new(big.Int).SetBytes(pKey.Y2),
+		Y3:                   new(big.Int).SetBytes(pKey.Y3),
+		Gamma:                &gamma,
+		VerifiableEncGroupN:  new(big.Int).SetBytes(pKey.VerifiableEncGroupN),
 		VerifiableEncGroupG1: new(big.Int).SetBytes(pKey.VerifiableEncGroupG1),
 		VerifiableEncGroupH1: new(big.Int).SetBytes(pKey.VerifiableEncGroupH1),
-		K: int(pKey.K),
-		K1: int(pKey.K1),
+		K:                    int(pKey.K),
+		K1:                   int(pKey.K1),
 	}
-	
+
 	var cspaillier CSPaillier
 
-	cspaillier = CSPaillier {
+	cspaillier = CSPaillier{
 		PubKey: &pubKey,
 	}
-	
-    return &cspaillier, nil
+
+	return &cspaillier, nil
 }
 
 func (cspaillier *CSPaillier) StoreSecKey(path string) error {
 	secKey := &pb.CSPaillierSecretKey{
-		N: cspaillier.SecretKey.N.Bytes(),
-		G: cspaillier.SecretKey.G.Bytes(),
-		X1: cspaillier.SecretKey.X1.Bytes(),
-		X2: cspaillier.SecretKey.X2.Bytes(),
-		X3: cspaillier.SecretKey.X3.Bytes(),
-		DLogP: cspaillier.SecretKey.Gamma.P.Bytes(),
-		DLogG: cspaillier.SecretKey.Gamma.G.Bytes(),
-		DLogQ: cspaillier.SecretKey.Gamma.OrderOfSubgroup.Bytes(),
-		VerifiableEncGroupN: cspaillier.SecretKey.VerifiableEncGroupN.Bytes(),
+		N:                    cspaillier.SecretKey.N.Bytes(),
+		G:                    cspaillier.SecretKey.G.Bytes(),
+		X1:                   cspaillier.SecretKey.X1.Bytes(),
+		X2:                   cspaillier.SecretKey.X2.Bytes(),
+		X3:                   cspaillier.SecretKey.X3.Bytes(),
+		DLogP:                cspaillier.SecretKey.Gamma.P.Bytes(),
+		DLogG:                cspaillier.SecretKey.Gamma.G.Bytes(),
+		DLogQ:                cspaillier.SecretKey.Gamma.OrderOfSubgroup.Bytes(),
+		VerifiableEncGroupN:  cspaillier.SecretKey.VerifiableEncGroupN.Bytes(),
 		VerifiableEncGroupG1: cspaillier.SecretKey.VerifiableEncGroupG1.Bytes(),
 		VerifiableEncGroupH1: cspaillier.SecretKey.VerifiableEncGroupH1.Bytes(),
-		K: int32(cspaillier.SecretKey.K),
-		K1: int32(cspaillier.SecretKey.K1),
+		K:                    int32(cspaillier.SecretKey.K),
+		K1:                   int32(cspaillier.SecretKey.K1),
 	}
 	data, err := proto.Marshal(secKey)
 	if err != nil {
 		return err
-	} 
+	}
 	err = common.Store(data, path)
 	if err != nil {
 		return err
-	} 
+	}
 	return nil
 }
 
 func (cspaillier *CSPaillier) StorePubKey(path string) error {
 	pubKey := &pb.CSPaillierPubKey{
-		N: cspaillier.PubKey.N.Bytes(),
-		G: cspaillier.PubKey.G.Bytes(),
-		Y1: cspaillier.PubKey.Y1.Bytes(),
-		Y2: cspaillier.PubKey.Y2.Bytes(),
-		Y3: cspaillier.PubKey.Y3.Bytes(),
-		DLogP: cspaillier.PubKey.Gamma.P.Bytes(),
-		DLogG: cspaillier.PubKey.Gamma.G.Bytes(),
-		DLogQ: cspaillier.PubKey.Gamma.OrderOfSubgroup.Bytes(),
-		VerifiableEncGroupN: cspaillier.PubKey.VerifiableEncGroupN.Bytes(),
+		N:                    cspaillier.PubKey.N.Bytes(),
+		G:                    cspaillier.PubKey.G.Bytes(),
+		Y1:                   cspaillier.PubKey.Y1.Bytes(),
+		Y2:                   cspaillier.PubKey.Y2.Bytes(),
+		Y3:                   cspaillier.PubKey.Y3.Bytes(),
+		DLogP:                cspaillier.PubKey.Gamma.P.Bytes(),
+		DLogG:                cspaillier.PubKey.Gamma.G.Bytes(),
+		DLogQ:                cspaillier.PubKey.Gamma.OrderOfSubgroup.Bytes(),
+		VerifiableEncGroupN:  cspaillier.PubKey.VerifiableEncGroupN.Bytes(),
 		VerifiableEncGroupG1: cspaillier.PubKey.VerifiableEncGroupG1.Bytes(),
 		VerifiableEncGroupH1: cspaillier.PubKey.VerifiableEncGroupH1.Bytes(),
-		K: int32(cspaillier.PubKey.K),
-		K1: int32(cspaillier.PubKey.K1),
+		K:                    int32(cspaillier.PubKey.K),
+		K1:                   int32(cspaillier.PubKey.K1),
 	}
 	data, err := proto.Marshal(pubKey)
 	if err != nil {
 		return err
-	} 
+	}
 	err = common.Store(data, path)
 	if err != nil {
 		return err
-	} 
+	}
 	return nil
 }
 
 // Returns (u, e, v).
 func (cspaillier *CSPaillier) Encrypt(m, label *big.Int) (*big.Int, *big.Int, *big.Int, error) {
 	if m.Cmp(cspaillier.PubKey.N) >= 0 {
-		err := errors.New("msg is too big")	
+		err := errors.New("msg is too big")
 		return nil, nil, nil, err
 	}
-	
+
 	b := new(big.Int).Div(cspaillier.PubKey.N, big.NewInt(4))
 	r := common.GetRandomInt(b)
-	
+
 	n2 := new(big.Int).Mul(cspaillier.PubKey.N, cspaillier.PubKey.N)
 	// u = g^r
 	u := new(big.Int).Exp(cspaillier.PubKey.G, r, n2)
-	
+
 	// e = y1^r * h^m
-	e1 := new(big.Int).Exp(cspaillier.PubKey.Y1, r, n2) // y1^r
+	e1 := new(big.Int).Exp(cspaillier.PubKey.Y1, r, n2)       // y1^r
 	h := new(big.Int).Add(cspaillier.PubKey.N, big.NewInt(1)) // 1 + n
-	e2 := new(big.Int).Exp(h, m, n2) // h^m
-		
+	e2 := new(big.Int).Exp(h, m, n2)                          // h^m
+
 	e := new(big.Int).Mul(e1, e2) // y1^r * h^m
 	e.Mod(e, n2)
-	
-	// v = abs((y2 * y3^hash(u, e, L))^r)	
+
+	// v = abs((y2 * y3^hash(u, e, L))^r)
 	hashNum := common.Hash(u, e, label)
-	
+
 	t := new(big.Int).Exp(cspaillier.PubKey.Y3, hashNum, n2) // y3^hashNum
-	t.Mul(cspaillier.PubKey.Y2, t) // y2 * y3^hashNum
-	t.Exp(t, r, n2) // (y2 * y3^hashNum)^r
-	
+	t.Mul(cspaillier.PubKey.Y2, t)                           // y2 * y3^hashNum
+	t.Exp(t, r, n2)                                          // (y2 * y3^hashNum)^r
+
 	v, _ := cspaillier.Abs(t)
-	
-	cspaillier.proverEncData = &CSPaillierProverEncData {
+
+	cspaillier.proverEncData = &CSPaillierProverEncData{
 		R: r,
 		M: m,
 	}
-		
+
 	return u, e, v, nil
 }
 
@@ -297,57 +297,57 @@ func (cspaillier *CSPaillier) Decrypt(u, e, v, label *big.Int) (*big.Int, error)
 	// check whether Abs(v) = v:
 	vAbs, _ := cspaillier.Abs(v)
 	if v.Cmp(vAbs) != 0 {
-		err := errors.New("v != abs(v)")	
+		err := errors.New("v != abs(v)")
 		return nil, err
 	}
-	
+
 	// check whether u^(2 * (x2 + hash(u, e, L) * x3)) = v^2:
 	// hash(u, e, L)
 	hashNum := common.Hash(u, e, label)
-	
+
 	// hash(u, e, L) * x3
 	t := new(big.Int).Mul(hashNum, cspaillier.SecretKey.X3)
-		
+
 	// x2 + hash(u, e, L) * x3:
 	t.Add(cspaillier.SecretKey.X2, t)
 	t.Mul(t, big.NewInt(2))
-	
+
 	n2 := new(big.Int).Mul(cspaillier.PubKey.N, cspaillier.PubKey.N)
 	t.Exp(u, t, n2)
 	t.Mod(t, n2)
-		
+
 	v2 := new(big.Int).Mul(v, v)
 	v2.Mod(v2, n2)
-	
+
 	if t.Cmp(v2) != 0 {
-		err := errors.New("CSPaillier decryption failed 1")	
+		err := errors.New("CSPaillier decryption failed 1")
 		return nil, err
 	}
-	
+
 	// check whether m1 is of the form h^m for some m from Z_n (meaning m1 = 1 + m * n)
 	ux1 := new(big.Int).Exp(u, cspaillier.SecretKey.X1, n2) // u^x1
-	ux1Inv := new(big.Int).ModInverse(ux1, n2) // u^x1_inv
-	
+	ux1Inv := new(big.Int).ModInverse(ux1, n2)              // u^x1_inv
+
 	m1 := new(big.Int).Mul(e, ux1Inv)
 	m1.Mod(m1, n2)
-	
+
 	m1min := new(big.Int).Sub(m1, big.NewInt(1))
 	m1minModulo := new(big.Int).Mod(m1min, cspaillier.PubKey.N)
 
 	if m1minModulo.Cmp(big.NewInt(0)) != 0 {
-		err := errors.New("CSPaillier decryption failed 2")	
+		err := errors.New("CSPaillier decryption failed 2")
 		return nil, err
 	}
-	
+
 	m := new(big.Int).Div(m1min, cspaillier.PubKey.N)
-	
+
 	return m, nil
 }
 
 func (cspaillier *CSPaillier) Abs(a *big.Int) (*big.Int, error) {
 	n2 := new(big.Int).Mul(cspaillier.PubKey.N, cspaillier.PubKey.N)
 	if a.Cmp(n2) >= 0 {
-		err := errors.New("value is too big for abs function")	
+		err := errors.New("value is too big for abs function")
 		return nil, err
 	}
 	b := new(big.Int).Div(n2, big.NewInt(2))
@@ -362,78 +362,78 @@ func (cspaillier *CSPaillier) Abs(a *big.Int) (*big.Int, error) {
 func (cspaillier *CSPaillier) generateKey() {
 	p1 := common.GetGermainPrime(cspaillier.SecParams.L)
 	q1 := common.GetGermainPrime(cspaillier.SecParams.L)
-	
+
 	p := new(big.Int).Add(p1, p1)
 	p.Add(p, big.NewInt(1))
-	
+
 	q := new(big.Int).Add(q1, q1)
 	q.Add(q, big.NewInt(1))
-	
+
 	//cspaillier.lambda = common.LCM(p_min, q_min)
 	n := new(big.Int).Mul(p, q)
-	cspaillier.n1 = new(big.Int).Mul(p1, q1)	
+	cspaillier.n1 = new(big.Int).Mul(p1, q1)
 	n2 := new(big.Int).Mul(n, n)
-	
-	pubKey := CSPaillierPubKey {
+
+	pubKey := CSPaillierPubKey{
 		N: n,
 	}
-	
-	// for verifiable encryption:	
+
+	// for verifiable encryption:
 	Gamma, err := dlog.NewZpSchnorr(cspaillier.SecParams.RoLength)
 	if err != nil {
 		log.Fatal(err)
 	}
 	pubKey.Gamma = Gamma
-	
+
 	// it must hold:
 	// 2**K < min{p1, q1, ro}; ro is Gamma.OrderOfSubgroup
 	// ro * 2**(K + K1 + 3) < n
 
 	check1 := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cspaillier.SecParams.K)), nil)
 	if check1.Cmp(p1) >= 0 || check1.Cmp(q1) >= 0 || check1.Cmp(Gamma.OrderOfSubgroup) >= 0 {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
-	
+
 	tmp := cspaillier.SecParams.K + cspaillier.SecParams.K1 + 3
 	check2 := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(tmp)), nil)
 	check2.Mul(check2, Gamma.OrderOfSubgroup)
-	
+
 	if check2.Cmp(n) >= 0 {
-		log.Fatal(err)	
+		log.Fatal(err)
 	}
-	
+
 	pubKey.K = cspaillier.SecParams.K
 	pubKey.K1 = cspaillier.SecParams.K1
-	
+
 	// Now we need to compute two generators in Z_n* subgroup of order n1.
-	// Note that here a different n might be used from the one in encryption, 
+	// Note that here a different n might be used from the one in encryption,
 	// however as above we assume the same (the paper says it can be the same).
 	orderOfZn := new(big.Int).Mul(big.NewInt(4), cspaillier.n1)
-	verifiableEncGroup, err := NewVerifiableEncGroup(n, orderOfZn, cspaillier.n1)		
+	verifiableEncGroup, err := NewVerifiableEncGroup(n, orderOfZn, cspaillier.n1)
 	if err != nil {
 		log.Fatal(err)
 	}
-	
+
 	pubKey.VerifiableEncGroupN = verifiableEncGroup.N
 	pubKey.VerifiableEncGroupG1 = verifiableEncGroup.G1
 	pubKey.VerifiableEncGroupH1 = verifiableEncGroup.H1
-	
-	secretKey := CSPaillierSecretKey {
-		N: n,
-		K: cspaillier.SecParams.K,
+
+	secretKey := CSPaillierSecretKey{
+		N:  n,
+		K:  cspaillier.SecParams.K,
 		K1: cspaillier.SecParams.K1,
 	}
 	secretKey.Gamma = Gamma
 	secretKey.VerifiableEncGroupN = verifiableEncGroup.N
 	secretKey.VerifiableEncGroupG1 = verifiableEncGroup.G1
 	secretKey.VerifiableEncGroupH1 = verifiableEncGroup.H1
-	
+
 	// choose x1, x2, x3 which are < n^2/4
 	b := new(big.Int).Div(n2, big.NewInt(4))
 	secretKey.X1 = common.GetRandomInt(b)
 	secretKey.X2 = common.GetRandomInt(b)
 	secretKey.X3 = common.GetRandomInt(b)
-	
+
 	for { // choose g1 from Z_n^2*
 		g1 := common.GetRandomInt(n2)
 		gcd := new(big.Int).GCD(nil, nil, g1, n2) // negligible probability that gcd != 1
@@ -445,7 +445,7 @@ func (cspaillier *CSPaillier) generateKey() {
 			break
 		}
 	}
-	
+
 	pubKey.Y1 = new(big.Int).Exp(pubKey.G, secretKey.X1, n2)
 	pubKey.Y2 = new(big.Int).Exp(pubKey.G, secretKey.X2, n2)
 	pubKey.Y3 = new(big.Int).Exp(pubKey.G, secretKey.X3, n2)
@@ -457,93 +457,93 @@ func (cspaillier *CSPaillier) generateKey() {
 func (cspaillier *CSPaillier) GetOpeningMsg(m *big.Int) (*big.Int, *big.Int) {
 	b := new(big.Int).Div(cspaillier.PubKey.VerifiableEncGroupN, big.NewInt(4))
 	s := common.GetRandomInt(b)
-	
-	t1 := new(big.Int).Exp(cspaillier.PubKey.VerifiableEncGroupG1, m, 
+
+	t1 := new(big.Int).Exp(cspaillier.PubKey.VerifiableEncGroupG1, m,
 		cspaillier.PubKey.VerifiableEncGroupN)
-	t2 := new(big.Int).Exp(cspaillier.PubKey.VerifiableEncGroupH1, s, 
+	t2 := new(big.Int).Exp(cspaillier.PubKey.VerifiableEncGroupH1, s,
 		cspaillier.PubKey.VerifiableEncGroupN)
 	l := new(big.Int).Mul(t1, t2)
 	l.Mod(l, cspaillier.PubKey.VerifiableEncGroupN)
-	
-	cspaillier.proverRandomData = &CSPaillierProverRandomData {
-		S: s,		
+
+	cspaillier.proverRandomData = &CSPaillierProverRandomData{
+		S: s,
 	}
-	
+
 	delta := new(big.Int).Exp(cspaillier.PubKey.Gamma.G, m, cspaillier.PubKey.Gamma.P)
 	return l, delta
 }
 
 // Prover (encryptor) should use this function to generate values for the first sigma protocol message.
-func (cspaillier *CSPaillier) GetProofRandomData(u, e, label *big.Int) (*big.Int, *big.Int, 
-		*big.Int, *big.Int, *big.Int, error) {
+func (cspaillier *CSPaillier) GetProofRandomData(u, e, label *big.Int) (*big.Int, *big.Int,
+	*big.Int, *big.Int, *big.Int, error) {
 	two := big.NewInt(2)
-	t1 := new(big.Int).Exp(two, big.NewInt(int64(cspaillier.PubKey.K + cspaillier.PubKey.K1 - 2)), nil)
+	t1 := new(big.Int).Exp(two, big.NewInt(int64(cspaillier.PubKey.K+cspaillier.PubKey.K1-2)), nil)
 	b1 := new(big.Int).Mul(cspaillier.PubKey.N, t1)
 	r1, err := common.GetRandomIntFromRange(new(big.Int).Neg(b1), b1)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
-	
+
 	b2 := new(big.Int).Mul(cspaillier.PubKey.VerifiableEncGroupN, t1)
 	s1, err := common.GetRandomIntFromRange(new(big.Int).Neg(b2), b2)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
-	
-	t2 := new(big.Int).Exp(two, big.NewInt(int64(cspaillier.PubKey.K + cspaillier.PubKey.K1)), nil)
+
+	t2 := new(big.Int).Exp(two, big.NewInt(int64(cspaillier.PubKey.K+cspaillier.PubKey.K1)), nil)
 	b3 := new(big.Int).Mul(cspaillier.PubKey.Gamma.OrderOfSubgroup, t2)
 	m1, err := common.GetRandomIntFromRange(new(big.Int).Neg(b3), b3)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}
-	
+
 	n2 := new(big.Int).Mul(cspaillier.PubKey.N, cspaillier.PubKey.N)
-	
+
 	// u1 = g^(2*r1)
-   	u1 := common.Exponentiate(cspaillier.PubKey.G, new(big.Int).Mul(big.NewInt(2), r1), n2)
-   	
-    // e1 = y1^(2*r1) * h^(2*m1)
+	u1 := common.Exponentiate(cspaillier.PubKey.G, new(big.Int).Mul(big.NewInt(2), r1), n2)
+
+	// e1 = y1^(2*r1) * h^(2*m1)
 	h := new(big.Int).Add(cspaillier.PubKey.N, big.NewInt(1)) // 1 + n
-   	e1Part1 := common.Exponentiate(cspaillier.PubKey.Y1, new(big.Int).Mul(big.NewInt(2), r1), n2)
-   	e1Part2 := common.Exponentiate(h, new(big.Int).Mul(big.NewInt(2), m1), n2)
+	e1Part1 := common.Exponentiate(cspaillier.PubKey.Y1, new(big.Int).Mul(big.NewInt(2), r1), n2)
+	e1Part2 := common.Exponentiate(h, new(big.Int).Mul(big.NewInt(2), m1), n2)
 	e1 := new(big.Int).Mul(e1Part1, e1Part2)
 	e1.Mod(e1, n2)
-	
-    // v1 = (y2 * y3^hash(u, e, L))^(2*r1)
+
+	// v1 = (y2 * y3^hash(u, e, L))^(2*r1)
 	hashNum := common.Hash(u, e, label)
-    v11 := new(big.Int).Exp(cspaillier.PubKey.Y3, hashNum, n2)
-    v11.Mul(v11, cspaillier.PubKey.Y2)
-    v11.Mod(v11, n2)
-   	v1 := common.Exponentiate(v11, new(big.Int).Mul(big.NewInt(2), r1), n2)
-   			
-    // delta1 = gamma^m1
-   	delta1 := common.Exponentiate(cspaillier.PubKey.Gamma.G, m1,
-   			cspaillier.PubKey.Gamma.P)
-    
-    // l1 = g1^m1 * h1^s1
-   	l11 := common.Exponentiate(cspaillier.PubKey.VerifiableEncGroupG1, m1, 
-    		cspaillier.PubKey.VerifiableEncGroupN)
-   	l12 := common.Exponentiate(cspaillier.PubKey.VerifiableEncGroupH1, s1, 
-    		cspaillier.PubKey.VerifiableEncGroupN)
-    l1 := new(big.Int).Mul(l11, l12)
-    l1.Mod(l1, cspaillier.PubKey.VerifiableEncGroupN)
-    
-    cspaillier.proverRandomData.R1 = r1
-    cspaillier.proverRandomData.S1 = s1
-    cspaillier.proverRandomData.M1 = m1
+	v11 := new(big.Int).Exp(cspaillier.PubKey.Y3, hashNum, n2)
+	v11.Mul(v11, cspaillier.PubKey.Y2)
+	v11.Mod(v11, n2)
+	v1 := common.Exponentiate(v11, new(big.Int).Mul(big.NewInt(2), r1), n2)
+
+	// delta1 = gamma^m1
+	delta1 := common.Exponentiate(cspaillier.PubKey.Gamma.G, m1,
+		cspaillier.PubKey.Gamma.P)
+
+	// l1 = g1^m1 * h1^s1
+	l11 := common.Exponentiate(cspaillier.PubKey.VerifiableEncGroupG1, m1,
+		cspaillier.PubKey.VerifiableEncGroupN)
+	l12 := common.Exponentiate(cspaillier.PubKey.VerifiableEncGroupH1, s1,
+		cspaillier.PubKey.VerifiableEncGroupN)
+	l1 := new(big.Int).Mul(l11, l12)
+	l1.Mod(l1, cspaillier.PubKey.VerifiableEncGroupN)
+
+	cspaillier.proverRandomData.R1 = r1
+	cspaillier.proverRandomData.S1 = s1
+	cspaillier.proverRandomData.M1 = m1
 	return u1, e1, v1, delta1, l1, nil
 }
 
 // Prover should use this function to compute data for second (last) sigma protocol message.
-func (cspaillier *CSPaillier) GetProofData(c *big.Int) (*big.Int, *big.Int, *big.Int) { 
+func (cspaillier *CSPaillier) GetProofData(c *big.Int) (*big.Int, *big.Int, *big.Int) {
 	// rTilde = r1 - c * r
 	t := new(big.Int).Mul(c, cspaillier.proverEncData.R)
 	rTilde := new(big.Int).Sub(cspaillier.proverRandomData.R1, t)
-	
+
 	// sTilde = s1 - c * s
 	t.Mul(c, cspaillier.proverRandomData.S)
 	sTilde := new(big.Int).Sub(cspaillier.proverRandomData.S1, t)
-	
+
 	// mTilde = m1 - c * m
 	t.Mul(c, cspaillier.proverEncData.M)
 	mTilde := new(big.Int).Sub(cspaillier.proverRandomData.M1, t)
@@ -555,10 +555,10 @@ func (cspaillier *CSPaillier) SetVerifierEncData(u, e, v, delta, label, l *big.I
 	cspaillier.verifierRandomData = &CSPaillierVerifierRandomData{
 		L: l,
 	}
-	cspaillier.verifierEncData = &CSPaillierVerifierEncData {
-		U: u,
-		E: e,
-		V: v,
+	cspaillier.verifierEncData = &CSPaillierVerifierEncData{
+		U:     u,
+		E:     e,
+		V:     v,
 		Label: label,
 		Delta: delta,
 	}
@@ -569,12 +569,12 @@ func (cspaillier *CSPaillier) Verify(rTilde, sTilde, mTilde *big.Int) bool {
 	// u = cspaillier.verifierEncData.U
 	// c = cspaillier.verifierRandomData.C
 	// g = cspaillier.PubKey.G
-	
-    // check if u1 = u^(2*c) * g^(2*rTilde)
+
+	// check if u1 = u^(2*c) * g^(2*rTilde)
 	n2 := new(big.Int).Mul(cspaillier.PubKey.N, cspaillier.PubKey.N)
 	twoC := new(big.Int).Mul(cspaillier.verifierRandomData.C, big.NewInt(2))
 	twoRTilde := new(big.Int).Mul(rTilde, big.NewInt(2))
-	
+
 	t1 := common.Exponentiate(cspaillier.verifierEncData.U, twoC, n2)
 	t2 := common.Exponentiate(cspaillier.SecretKey.G, twoRTilde, n2)
 	t := new(big.Int).Mul(t1, t2)
@@ -583,8 +583,8 @@ func (cspaillier *CSPaillier) Verify(rTilde, sTilde, mTilde *big.Int) bool {
 		log.Println("NOT OK 1")
 		return false
 	}
-	
-    // check if e1 = e^(2*c) * y1^(2*rTilde) * h^(2*mTilde)
+
+	// check if e1 = e^(2*c) * y1^(2*rTilde) * h^(2*mTilde)
 	t1 = common.Exponentiate(cspaillier.verifierEncData.E, twoC, n2)
 	y1 := common.Exponentiate(cspaillier.SecretKey.G, cspaillier.SecretKey.X1, n2)
 	t2 = common.Exponentiate(y1, twoRTilde, n2)
@@ -597,10 +597,10 @@ func (cspaillier *CSPaillier) Verify(rTilde, sTilde, mTilde *big.Int) bool {
 		log.Println("NOT OK 2")
 		return false
 	}
-	
-    // check if v1 = v^(2*c) * (y2 * y3^hash(u, e, L))^(2*rTilde)
+
+	// check if v1 = v^(2*c) * (y2 * y3^hash(u, e, L))^(2*rTilde)
 	t1 = common.Exponentiate(cspaillier.verifierEncData.V, twoC, n2)
-	hashNum := common.Hash(cspaillier.verifierEncData.U, cspaillier.verifierEncData.E, 
+	hashNum := common.Hash(cspaillier.verifierEncData.U, cspaillier.verifierEncData.E,
 		cspaillier.verifierEncData.Label)
 	y3 := common.Exponentiate(cspaillier.SecretKey.G, cspaillier.SecretKey.X3, n2)
 	t21 := new(big.Int).Exp(y3, hashNum, n2)
@@ -609,54 +609,54 @@ func (cspaillier *CSPaillier) Verify(rTilde, sTilde, mTilde *big.Int) bool {
 	t2 = common.Exponentiate(t21, twoRTilde, n2)
 	t.Mul(t1, t2)
 	t.Mod(t, n2)
-    if cspaillier.verifierRandomData.V1.Cmp(t) != 0 {
+	if cspaillier.verifierRandomData.V1.Cmp(t) != 0 {
 		log.Println("NOT OK 3")
 		return false
 	}
-	
-    // check if delta1 = delta^c * Gamma.G^mTilde
-    t1.Exp(cspaillier.verifierEncData.Delta, cspaillier.verifierRandomData.C, 
-    	cspaillier.SecretKey.Gamma.P)
-    t2 = common.Exponentiate(cspaillier.SecretKey.Gamma.G, mTilde, cspaillier.SecretKey.Gamma.P)
+
+	// check if delta1 = delta^c * Gamma.G^mTilde
+	t1.Exp(cspaillier.verifierEncData.Delta, cspaillier.verifierRandomData.C,
+		cspaillier.SecretKey.Gamma.P)
+	t2 = common.Exponentiate(cspaillier.SecretKey.Gamma.G, mTilde, cspaillier.SecretKey.Gamma.P)
 	t.Mul(t1, t2)
 	t.Mod(t, cspaillier.SecretKey.Gamma.P)
 	if cspaillier.verifierRandomData.Delta1.Cmp(t) != 0 {
 		log.Println("NOT OK 4")
 		return false
 	}
-	
-    // check if l1 = l^c * g1^mTilde * h1^sTilde
-    t1.Exp(cspaillier.verifierRandomData.L, cspaillier.verifierRandomData.C, n2)
-    t2 = common.Exponentiate(cspaillier.SecretKey.VerifiableEncGroupG1, 
-    	mTilde, cspaillier.SecretKey.VerifiableEncGroupN)
-    t3 = common.Exponentiate(cspaillier.SecretKey.VerifiableEncGroupH1, 
-    	sTilde, cspaillier.SecretKey.VerifiableEncGroupN)
-    t.Mul(t1, t2)
+
+	// check if l1 = l^c * g1^mTilde * h1^sTilde
+	t1.Exp(cspaillier.verifierRandomData.L, cspaillier.verifierRandomData.C, n2)
+	t2 = common.Exponentiate(cspaillier.SecretKey.VerifiableEncGroupG1,
+		mTilde, cspaillier.SecretKey.VerifiableEncGroupN)
+	t3 = common.Exponentiate(cspaillier.SecretKey.VerifiableEncGroupH1,
+		sTilde, cspaillier.SecretKey.VerifiableEncGroupN)
+	t.Mul(t1, t2)
 	t.Mul(t, t3)
 	t.Mod(t, cspaillier.SecretKey.VerifiableEncGroupN)
 	if cspaillier.verifierRandomData.L1.Cmp(t) != 0 {
 		log.Println("NOT OK 5")
 		return false
 	}
-	
-    // check if -n/4 < mTilde < n/4
-    b := new(big.Int).Div(cspaillier.PubKey.N, big.NewInt(4))
-    if new(big.Int).Abs(mTilde).Cmp(b) >= 0 {
+
+	// check if -n/4 < mTilde < n/4
+	b := new(big.Int).Div(cspaillier.PubKey.N, big.NewInt(4))
+	if new(big.Int).Abs(mTilde).Cmp(b) >= 0 {
 		log.Println("NOT OK 6")
 		return false
-    }
-    
-    return true
+	}
+
+	return true
 }
 
-func (cspaillier *CSPaillier) GetChallenge () *big.Int {
+func (cspaillier *CSPaillier) GetChallenge() *big.Int {
 	b := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cspaillier.SecretKey.K)), nil)
 	c := common.GetRandomInt(b)
 	return c
 }
 
 // Verifier should call this function when it receives proof random data as the second protocol message.
-func (cspaillier *CSPaillier) SetProofRandomData (u1, e1, v1, delta1, l1, c *big.Int) {
+func (cspaillier *CSPaillier) SetProofRandomData(u1, e1, v1, delta1, l1, c *big.Int) {
 	cspaillier.verifierRandomData.U1 = u1
 	cspaillier.verifierRandomData.E1 = e1
 	cspaillier.verifierRandomData.V1 = v1
@@ -666,11 +666,11 @@ func (cspaillier *CSPaillier) SetProofRandomData (u1, e1, v1, delta1, l1, c *big
 }
 
 type VerifiableEncGroup struct {
-	N *big.Int
+	N  *big.Int
 	N1 *big.Int
 	G1 *big.Int
 	H1 *big.Int
-	l *big.Int
+	l  *big.Int
 }
 
 func NewVerifiableEncGroup(n, orderOfZn, n1 *big.Int) (*VerifiableEncGroup, error) {
@@ -680,18 +680,12 @@ func NewVerifiableEncGroup(n, orderOfZn, n1 *big.Int) (*VerifiableEncGroup, erro
 		log.Fatal(err)
 		return nil, err
 	}
-	
-	group := VerifiableEncGroup {
-		N: n,
+
+	group := VerifiableEncGroup{
+		N:  n,
 		N1: n1,
 		G1: g1,
-		H1: h1,	
+		H1: h1,
 	}
 	return &group, nil
 }
-
-
-
-
-
-

--- a/pseudonymsys/org_c_transfer.go
+++ b/pseudonymsys/org_c_transfer.go
@@ -1,34 +1,34 @@
 package pseudonymsys
 
 import (
-	"math/big"
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/dlog"
 	"github.com/xlab-si/emmy/dlogproofs"
+	"math/big"
 )
 
 type OrgCredentialVerifier struct {
 	DLog *dlog.ZpDLog
-	s1 *big.Int
-	s2 *big.Int
-	
+	s1   *big.Int
+	s2   *big.Int
+
 	EqualityVerifier *dlogproofs.DLogEqualityVerifier
-	a *big.Int
-	b *big.Int
+	a                *big.Int
+	b                *big.Int
 }
 
-func NewOrgCredentialVerifier(orgName string) (*OrgCredentialVerifier) {
+func NewOrgCredentialVerifier(orgName string) *OrgCredentialVerifier {
 	dlog := config.LoadDLog("pseudonymsys")
 	s1, s2 := config.LoadPseudonymsysOrgSecrets(orgName)
 
 	equalityVerifier := dlogproofs.NewDLogEqualityVerifier(dlog)
-	org := OrgCredentialVerifier {
-		DLog: dlog,	
-		s1: s1,
-		s2: s2,
+	org := OrgCredentialVerifier{
+		DLog:             dlog,
+		s1:               s1,
+		s2:               s2,
 		EqualityVerifier: equalityVerifier,
 	}
-	
+
 	return &org
 }
 
@@ -42,29 +42,25 @@ func (org *OrgCredentialVerifier) GetAuthenticationChallenge(a, b, a1, b1, x1, x
 }
 
 func (org *OrgCredentialVerifier) VerifyAuthentication(z *big.Int,
-		credential *PseudonymCredential, orgPubKeys *OrgPubKeys) bool {
+	credential *PseudonymCredential, orgPubKeys *OrgPubKeys) bool {
 	verified := org.EqualityVerifier.Verify(z)
 	if !verified {
 		// TODO: close the session
 	}
-	
-	valid1 := dlogproofs.VerifyBlindedTranscript(credential.T1, org.DLog, org.DLog.G, orgPubKeys.H2, 
+
+	valid1 := dlogproofs.VerifyBlindedTranscript(credential.T1, org.DLog, org.DLog.G, orgPubKeys.H2,
 		credential.SmallBToGamma, credential.AToGamma)
-	
+
 	aAToGamma, _ := org.DLog.Multiply(credential.SmallAToGamma, credential.AToGamma)
-	valid2 := dlogproofs.VerifyBlindedTranscript(credential.T2, org.DLog, org.DLog.G, orgPubKeys.H1, 
+	valid2 := dlogproofs.VerifyBlindedTranscript(credential.T2, org.DLog, org.DLog.G, orgPubKeys.H1,
 		aAToGamma, credential.BToGamma)
 
 	if valid1 && valid2 {
-		return true	
+		return true
 	} else {
-		// TODO: close the session	
+		// TODO: close the session
 
 		return false
 	}
-	
+
 }
-	
-
-
-

--- a/pseudonymsys/org_nym_gen.go
+++ b/pseudonymsys/org_nym_gen.go
@@ -1,33 +1,33 @@
 package pseudonymsys
 
 import (
-	"math/big"
 	"github.com/xlab-si/emmy/common"
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/dlog"
 	"github.com/xlab-si/emmy/dlogproofs"
+	"math/big"
 )
 
 type OrgNymGen struct {
-	DLog *dlog.ZpDLog
+	DLog             *dlog.ZpDLog
 	EqualityVerifier *dlogproofs.DLogEqualityVerifier
-	a *big.Int
-	b *big.Int
-	a_tilde *big.Int
-	b_tilde *big.Int
+	a                *big.Int
+	b                *big.Int
+	a_tilde          *big.Int
+	b_tilde          *big.Int
 }
 
-func NewOrgNymGen(orgName string) (*OrgNymGen) {
+func NewOrgNymGen(orgName string) *OrgNymGen {
 	dlog := config.LoadDLog("pseudonymsys")
 
 	// g1 = a_tilde, t1 = b_tilde,
 	// g2 = a, t2 = b
 	verifier := dlogproofs.NewDLogEqualityVerifier(dlog)
-	org := OrgNymGen {
-		DLog: dlog,	
+	org := OrgNymGen{
+		DLog:             dlog,
 		EqualityVerifier: verifier,
 	}
-	
+
 	return &org
 }
 
@@ -43,7 +43,7 @@ func (org *OrgNymGen) GetFirstReply(a_tilde, b_tilde *big.Int) *big.Int {
 }
 
 func (org *OrgNymGen) GetChallenge(x1, x2 *big.Int) *big.Int {
-	challenge := org.EqualityVerifier.GetChallenge(org.a_tilde, org.a, 
+	challenge := org.EqualityVerifier.GetChallenge(org.a_tilde, org.a,
 		org.b_tilde, org.b, x1, x2)
 	return challenge
 }
@@ -51,11 +51,7 @@ func (org *OrgNymGen) GetChallenge(x1, x2 *big.Int) *big.Int {
 func (org *OrgNymGen) Verify(z *big.Int) bool {
 	verified := org.EqualityVerifier.Verify(z)
 	if verified {
-		// TODO: store (a, b) into a database	
+		// TODO: store (a, b) into a database
 	}
 	return verified
 }
-
-
-
-	

--- a/pseudonymsys/org_nym_gen_verify_master.go
+++ b/pseudonymsys/org_nym_gen_verify_master.go
@@ -1,37 +1,37 @@
 package pseudonymsys
 
 import (
-	"math/big"
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"errors"
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/common"
+	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/dlog"
 	"github.com/xlab-si/emmy/dlogproofs"
+	"math/big"
 )
 
 type OrgNymGenMasterVerifier struct {
-	DLog *dlog.ZpDLog
+	DLog             *dlog.ZpDLog
 	EqualityVerifier *dlogproofs.DLogEqualityVerifier
 }
 
-func NewOrgNymGenMasterVerifier(orgName string) (*OrgNymGenMasterVerifier) {
+func NewOrgNymGenMasterVerifier(orgName string) *OrgNymGenMasterVerifier {
 	dlog := config.LoadDLog("pseudonymsys")
 	verifier := dlogproofs.NewDLogEqualityVerifier(dlog)
-	org := OrgNymGenMasterVerifier {
-		DLog: dlog,	
+	org := OrgNymGenMasterVerifier{
+		DLog:             dlog,
 		EqualityVerifier: verifier,
 	}
 	return &org
 }
 
-func (org *OrgNymGenMasterVerifier) GetChallenge(nymA, blindedA, nymB, blindedB, 
-		x1, x2, r, s *big.Int, caName string) (*big.Int, error) {
+func (org *OrgNymGenMasterVerifier) GetChallenge(nymA, blindedA, nymB, blindedB,
+	x1, x2, r, s *big.Int, caName string) (*big.Int, error) {
 	x, y := config.LoadPseudonymsysCAPubKey(caName)
 	c := elliptic.P256()
 	pubKey := ecdsa.PublicKey{Curve: c, X: x, Y: y}
-	
+
 	hashed := common.HashIntoBytes(blindedA, blindedB)
 	verified := ecdsa.Verify(&pubKey, hashed, r, s)
 	if verified {
@@ -40,19 +40,15 @@ func (org *OrgNymGenMasterVerifier) GetChallenge(nymA, blindedA, nymB, blindedB,
 	} else {
 		// TODO: end session
 
-		err := errors.New("The signature is not valid.")	
+		err := errors.New("The signature is not valid.")
 		return nil, err
-	}		
+	}
 }
 
 func (org *OrgNymGenMasterVerifier) Verify(z *big.Int) bool {
 	verified := org.EqualityVerifier.Verify(z)
 	if verified {
-		// TODO: store (a, b) into a database	
+		// TODO: store (a, b) into a database
 	}
 	return verified
 }
-
-
-
-	

--- a/pseudonymsys/user_c_issue.go
+++ b/pseudonymsys/user_c_issue.go
@@ -1,11 +1,11 @@
 package pseudonymsys
 
 import (
-	"math/big"
 	"errors"
 	"github.com/xlab-si/emmy/common"
 	"github.com/xlab-si/emmy/dlog"
 	"github.com/xlab-si/emmy/dlogproofs"
+	"math/big"
 )
 
 type OrgPubKeys struct {
@@ -16,32 +16,32 @@ type OrgPubKeys struct {
 type PseudonymCredential struct {
 	SmallAToGamma *big.Int
 	SmallBToGamma *big.Int
-	AToGamma *big.Int
-	BToGamma *big.Int
-	T1 []*big.Int
-	T2 []*big.Int
+	AToGamma      *big.Int
+	BToGamma      *big.Int
+	T1            []*big.Int
+	T2            []*big.Int
 }
 
-func IssueCredential(userSecret *big.Int, nym *Pseudonym, 
-		orgName string, orgPubKeys *OrgPubKeys, dlog *dlog.ZpDLog) (*PseudonymCredential, error) {
+func IssueCredential(userSecret *big.Int, nym *Pseudonym,
+	orgName string, orgPubKeys *OrgPubKeys, dlog *dlog.ZpDLog) (*PseudonymCredential, error) {
 	gamma := common.GetRandomInt(dlog.GetOrderOfSubgroup())
 	equalityVerifier1 := dlogproofs.NewDLogEqualityBTranscriptVerifier(dlog, gamma)
 	equalityVerifier2 := dlogproofs.NewDLogEqualityBTranscriptVerifier(dlog, gamma)
 	org := NewOrgCredentialIssuer(orgName)
-	
+
 	// First we need to authenticate - prove that we know dlog_a(b) where (a, b) is a nym registered
 	// with this organization. Authentication is done via Schnorr.
 	schnorrProver := dlogproofs.NewSchnorrProver(dlog, common.Sigma)
 	x := schnorrProver.GetProofRandomData(userSecret, nym.A)
-	
+
 	challenge := org.GetAuthenticationChallenge(nym.A, nym.B, x)
 	z, _ := schnorrProver.GetProofData(challenge)
-	
+
 	x11, x12, x21, x22, A, B, err := org.VerifyAuthentication(z)
 	if err != nil {
 		return nil, err
 	}
-	
+
 	// Now the organization needs to prove that it knows log_b(A), log_g(h2) and log_b(A) = log_g(h2).
 	// And to prove that it knows log_aA(B), log_g(h1) and log_aA(B) = log_g(h1).
 	// g1 = dlog.G, g2 = nym.B, t1 = A, t2 = orgPubKeys.H2
@@ -49,39 +49,33 @@ func IssueCredential(userSecret *big.Int, nym *Pseudonym,
 	challenge1 := equalityVerifier1.GetChallenge(dlog.G, nym.B, orgPubKeys.H2, A, x11, x12)
 	aA, _ := dlog.Multiply(nym.A, A)
 	challenge2 := equalityVerifier2.GetChallenge(dlog.G, aA, orgPubKeys.H1, B, x21, x22)
-	
+
 	z1, z2 := org.GetEqualityProofData(challenge1, challenge2)
 
 	verified1, transcript1, bToGamma, AToGamma := equalityVerifier1.Verify(z1)
 	verified2, transcript2, aAToGamma, BToGamma := equalityVerifier2.Verify(z2)
-	
+
 	aToGamma, _ := dlog.Exponentiate(nym.A, gamma)
 	if verified1 && verified2 {
-		valid1 := dlogproofs.VerifyBlindedTranscript(transcript1, dlog, dlog.G, orgPubKeys.H2, 
+		valid1 := dlogproofs.VerifyBlindedTranscript(transcript1, dlog, dlog.G, orgPubKeys.H2,
 			bToGamma, AToGamma)
-		valid2 := dlogproofs.VerifyBlindedTranscript(transcript2, dlog, dlog.G, orgPubKeys.H1, 
+		valid2 := dlogproofs.VerifyBlindedTranscript(transcript2, dlog, dlog.G, orgPubKeys.H1,
 			aAToGamma, BToGamma)
 		if valid1 && valid2 {
 			credential := PseudonymCredential{
 				SmallAToGamma: aToGamma,
 				SmallBToGamma: bToGamma,
-				AToGamma: AToGamma,
-				BToGamma: BToGamma,
-				T1: transcript1,
-				T2: transcript2,
+				AToGamma:      AToGamma,
+				BToGamma:      BToGamma,
+				T1:            transcript1,
+				T2:            transcript2,
 			}
-			
-			return &credential, nil					
+
+			return &credential, nil
 		}
-		
+
 	}
 
-	err = errors.New("Organization failed to prove that a credential is valid.")	
+	err = errors.New("Organization failed to prove that a credential is valid.")
 	return nil, err
 }
-
-	
-	
-	
-		
-	

--- a/pseudonymsys/user_c_transfer.go
+++ b/pseudonymsys/user_c_transfer.go
@@ -1,39 +1,33 @@
 package pseudonymsys
 
 import (
-	"math/big"
 	"errors"
 	"github.com/xlab-si/emmy/dlog"
 	"github.com/xlab-si/emmy/dlogproofs"
+	"math/big"
 )
 
-func TransferCredential(userSecret *big.Int, credential *PseudonymCredential, nym *Pseudonym, 
-		orgName string, orgPubKeys *OrgPubKeys, dlog *dlog.ZpDLog) (bool, error) {
+func TransferCredential(userSecret *big.Int, credential *PseudonymCredential, nym *Pseudonym,
+	orgName string, orgPubKeys *OrgPubKeys, dlog *dlog.ZpDLog) (bool, error) {
 	org := NewOrgCredentialVerifier(orgName)
-	
+
 	// First we need to authenticate - prove that we know dlog_a(b) where (a, b) is a nym registered
 	// with this organization. But we need also to prove that dlog_a(b) = dlog_a2(b2), where
-	// a2, b2 are a1, b1 exponentiated to gamma, and (a1, b1) is a nym for organization that 
+	// a2, b2 are a1, b1 exponentiated to gamma, and (a1, b1) is a nym for organization that
 	// issued a credential. So we can do both proofs at the same time using DLogEqualityProver.
 	equalityProver := dlogproofs.NewDLogEqualityProver(dlog)
 	x1, x2 := equalityProver.GetProofRandomData(userSecret, nym.A, credential.SmallAToGamma)
-	
+
 	// nym.B = b
-	challenge := org.GetAuthenticationChallenge(nym.A, nym.B, 
+	challenge := org.GetAuthenticationChallenge(nym.A, nym.B,
 		credential.SmallAToGamma, credential.SmallBToGamma, x1, x2)
 	z := equalityProver.GetProofData(challenge)
-	
+
 	verified := org.VerifyAuthentication(z, credential, orgPubKeys)
 	if !verified {
-		err := errors.New("Authentication with organization failed.")	
-		return false, err	
+		err := errors.New("Authentication with organization failed.")
+		return false, err
 	}
-	
-	return true, nil	
-}
 
-	
-	
-	
-		
-	
+	return true, nil
+}

--- a/pseudonymsys/user_ca_register.go
+++ b/pseudonymsys/user_ca_register.go
@@ -9,7 +9,7 @@ import (
 )
 
 func RegisterWithCA(caName string, userSecret *big.Int, nym Pseudonym, dlog *dlog.ZpDLog) (*big.Int,
-		*big.Int, *big.Int, *big.Int, error) {
+	*big.Int, *big.Int, *big.Int, error) {
 	schnorrProver := dlogproofs.NewSchnorrProver(dlog, common.Sigma)
 	x := schnorrProver.GetProofRandomData(userSecret, nym.A)
 
@@ -24,6 +24,3 @@ func RegisterWithCA(caName string, userSecret *big.Int, nym Pseudonym, dlog *dlo
 		return nil, nil, nil, nil, err
 	}
 }
-
-		
-	

--- a/pseudonymsys/user_nym_gen.go
+++ b/pseudonymsys/user_nym_gen.go
@@ -1,11 +1,11 @@
 package pseudonymsys
 
 import (
-	"math/big"
 	"errors"
 	"github.com/xlab-si/emmy/common"
 	"github.com/xlab-si/emmy/dlog"
 	"github.com/xlab-si/emmy/dlogproofs"
+	"math/big"
 )
 
 type Pseudonym struct {
@@ -37,12 +37,12 @@ func GenerateNym(userSecret *big.Int, orgName string, dlog *dlog.ZpDLog) *Pseudo
 		// todo: store in some DB: (orgName, nymA, nymB)
 		return &Pseudonym{A: a, B: b}
 	} else {
-		return nil	
+		return nil
 	}
 }
 
-func GenerateNymVerifyMaster(userSecret, blindedA, blindedB, r, s *big.Int, 
-		orgName, caName string, dlog *dlog.ZpDLog) (*Pseudonym, error) {
+func GenerateNymVerifyMaster(userSecret, blindedA, blindedB, r, s *big.Int,
+	orgName, caName string, dlog *dlog.ZpDLog) (*Pseudonym, error) {
 	prover := dlogproofs.NewDLogEqualityProver(dlog)
 	org := NewOrgNymGenMasterVerifier(orgName)
 
@@ -54,7 +54,7 @@ func GenerateNymVerifyMaster(userSecret, blindedA, blindedB, r, s *big.Int,
 	x1, x2 := prover.GetProofRandomData(userSecret, nymA, blindedA)
 	challenge, err := org.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2, r, s, caName)
 	if err != nil {
-		return nil, err	
+		return nil, err
 	}
 
 	z := prover.GetProofData(challenge)
@@ -64,11 +64,7 @@ func GenerateNymVerifyMaster(userSecret, blindedA, blindedB, r, s *big.Int,
 		// todo: store in some DB: (orgName, nymA, nymB)
 		return &Pseudonym{A: nymA, B: nymB}, nil
 	} else {
-		err := errors.New("The proof for nym registration failed.")	
+		err := errors.New("The proof for nym registration failed.")
 		return nil, err
 	}
 }
-
-
-
-

--- a/secretsharing/dealer.go
+++ b/secretsharing/dealer.go
@@ -1,10 +1,10 @@
 package secretsharing
 
 import (
-	"math/big"
-	"errors"
 	"crypto/rand"
+	"errors"
 	"github.com/xlab-si/emmy/common"
+	"math/big"
 )
 
 // Shamir's secret sharing scheme
@@ -12,64 +12,57 @@ type Dealer struct {
 }
 
 func NewDealer() (*Dealer, error) {
-	dealer := Dealer {
-	}
-	
+	dealer := Dealer{}
+
 	return &dealer, nil
 }
 
-func (dealer *Dealer) SplitSecret(secret string, threshold int, 
-		numberOfShares int) (map[*big.Int]*big.Int, *big.Int, error) {
+func (dealer *Dealer) SplitSecret(secret string, threshold int,
+	numberOfShares int) (map[*big.Int]*big.Int, *big.Int, error) {
 	if threshold < 2 {
-		err := errors.New("the threshold should be at least 2")	
+		err := errors.New("the threshold should be at least 2")
 		return nil, nil, err
 	}
 	if threshold > numberOfShares {
-		err := errors.New("the threshold should be smaller than the number of shares")	
+		err := errors.New("the threshold should be smaller than the number of shares")
 		return nil, nil, err
 	}
-	
+
 	b := []byte(secret)
 	secretNum := new(big.Int).SetBytes(b)
-	
+
 	// generate some random prime which will be bigger than numberOfShares and secretNum
 	if secretNum.Cmp(big.NewInt(int64(numberOfShares))) < 0 {
-		err := errors.New("the number of shares (participants) is too high")	
+		err := errors.New("the number of shares (participants) is too high")
 		return nil, nil, err
 	}
-	
-	prime, err := rand.Prime(rand.Reader, secretNum.BitLen() + 1)
+
+	prime, err := rand.Prime(rand.Reader, secretNum.BitLen()+1)
 	if err != nil {
 		return nil, nil, err
 	}
-	
+
 	if prime.Cmp(big.NewInt(int64(numberOfShares))) < 0 {
-		err := errors.New("the number of shares (participants) is too high")	
+		err := errors.New("the number of shares (participants) is too high")
 		return nil, nil, err
 	}
-	
+
 	polynomial, _ := common.NewRandomPolynomial(threshold-1, prime)
 	polynomial.SetCoefficient(0, secretNum)
-	
+
 	var ps []*big.Int
 	for i := 0; i < numberOfShares; i++ {
 		ps = append(ps, big.NewInt(int64(i)))
-	} 
+	}
 	points := polynomial.GetValues(ps)
-	
+
 	return points, prime, nil
 }
 
-// It takes threshold 
-func (dealer *Dealer) RecoverSecret(points map[*big.Int]*big.Int, prime *big.Int) (string) {
+// It takes threshold
+func (dealer *Dealer) RecoverSecret(points map[*big.Int]*big.Int, prime *big.Int) string {
 	secretNum := common.LagrangeInterpolation(big.NewInt(0), points, prime)
-	
+
 	b := secretNum.Bytes()
 	return string(b)
 }
-
-
-
-
-
-

--- a/signatures/cl.go
+++ b/signatures/cl.go
@@ -1,20 +1,20 @@
 package signatures
 
 import (
-	"math/big"
 	"crypto/rand"
 	"errors"
-	"log"
 	"github.com/xlab-si/emmy/common"
+	"log"
+	"math/big"
 )
 
 type CL struct {
 	// http://groups.csail.mit.edu/cis/pubs/lysyanskaya/cl02b.pdf
 	numOfBlocks int
-	config *CLConfig
-	p *big.Int
-	q *big.Int
-	pubKey *CLPubKey
+	config      *CLConfig
+	p           *big.Int
+	q           *big.Int
+	pubKey      *CLPubKey
 }
 
 type CLSignature struct {
@@ -26,43 +26,43 @@ type CLSignature struct {
 type CLConfig struct {
 	l_n int
 	l_m int
-	l int
+	l   int
 }
 
 type CLPubKey struct {
-	n *big.Int
+	n   *big.Int
 	a_L []*big.Int
-	b *big.Int
-	c *big.Int
+	b   *big.Int
+	c   *big.Int
 }
 
 func NewCL(numOfBlocks int) *CL {
-	config := CLConfig {
-		l_n: 1024,	
+	config := CLConfig{
+		l_n: 1024,
 		l_m: 160,
-		l: 160,
+		l:   160,
 	}
-	
+
 	cl := CL{
 		numOfBlocks: numOfBlocks,
-		config: &config,
+		config:      &config,
 	}
 	cl.generateKey()
 	return &cl
 }
 
 func NewPubCL(pubKey *CLPubKey) *CL {
-	config := CLConfig {
-		l_n: 1024,	
+	config := CLConfig{
+		l_n: 1024,
 		l_m: 160,
-		l: 160,
+		l:   160,
 	}
-	
+
 	cl := CL{
 		config: &config,
 		pubKey: pubKey,
 	}
-	
+
 	return &cl
 }
 
@@ -73,75 +73,75 @@ func (cl *CL) getQuadraticResidues(n *big.Int) ([]*big.Int, *big.Int, *big.Int) 
 		a := new(big.Int).Mul(aRoot, aRoot)
 		a.Mod(a, n)
 		a_L = append(a_L, a)
-    }
-	
+	}
+
 	bRoot := common.GetRandomInt(n)
 	cRoot := common.GetRandomInt(n)
 	b := new(big.Int).Mul(bRoot, bRoot)
 	b.Mod(b, n)
 	c := new(big.Int).Mul(cRoot, cRoot)
 	c.Mod(c, n)
-	
+
 	return a_L, b, c
 }
 
 func (cl *CL) Sign(m_Ls []*big.Int) (*CLSignature, error) {
 	if cl.numOfBlocks != len(m_Ls) {
-		err := errors.New("the number of message blocks is not correct")	
+		err := errors.New("the number of message blocks is not correct")
 		return nil, err
 	}
 
 	// each m should be in [0, 2^l_m)
 	for _, m_L := range m_Ls {
 		if m_L.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m)), nil)) > -1 {
-			err := errors.New("msg is too big")	
+			err := errors.New("msg is too big")
 			return nil, err
 		}
-    }
+	}
 
 	// choose a random prime number e > 2^(l_m+1) of length l_e = l_m + 2
 	// that means: 2^(l_m+1) < e < 2^(l_m+2)
-	e, _ := rand.Prime(rand.Reader, cl.config.l_m + 2)
-	
+	e, _ := rand.Prime(rand.Reader, cl.config.l_m+2)
+
 	b1 := e.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m+1)), nil))
 	b2 := e.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m+2)), nil))
 	if (b1 != 1) || (b2 != -1) {
 		log.Panic("parameter not properly chosen")
 	}
-	
+
 	s := common.GetRandomIntOfLength(cl.config.l_n + cl.config.l_m + cl.config.l)
-	
+
 	// v^e = a_1^m_1 * ... * a_L^m_L * b^s * c % n
-	
+
 	a := new(big.Int)
 	for i := 0; i < cl.numOfBlocks; i++ {
 		a = new(big.Int).Exp(cl.pubKey.a_L[i], m_Ls[i], cl.pubKey.n)
-    }
-	
+	}
+
 	t2 := new(big.Int).Exp(cl.pubKey.b, s, cl.pubKey.n) // b^s (mod n)
-	t := new(big.Int).Mul(a, t2) // a_1^m_1 * ... * a_L^m_L * b^s (mod n)
+	t := new(big.Int).Mul(a, t2)                        // a_1^m_1 * ... * a_L^m_L * b^s (mod n)
 	t = new(big.Int).Mul(t, cl.pubKey.c)
 	t = new(big.Int).Mod(t, cl.pubKey.n)
-	
+
 	pMin1 := new(big.Int).Sub(cl.p, big.NewInt(1))
 	qMin1 := new(big.Int).Sub(cl.q, big.NewInt(1))
 	phi_n := new(big.Int).Mul(pMin1, qMin1) // how many invertible elements in Z_n (used for Euler's theorem)
-	
+
 	eInv := new(big.Int).ModInverse(e, phi_n)
-	
-	// now we have: e*eInv = 1 (mod phi_n), 
+
+	// now we have: e*eInv = 1 (mod phi_n),
 	// which means there exists k such that: e*eInv = k*phi_n + 1
 	// v can be calculated as (modulus is omitted):
 	// v^(e*eInv) = v^(k*phi_n+1) = v^(k*phi_n) * v = v,
 	// because v^(k*phi_n) = (v^phi_n)^k = 1^k = 1 due to Euler's theorem
 	v := new(big.Int).Exp(t, eInv, cl.pubKey.n)
-		
+
 	signature := CLSignature{
 		e: e,
 		s: s,
 		v: v,
 	}
-	
+
 	return &signature, nil
 }
 
@@ -149,36 +149,36 @@ func (cl *CL) Verify(m_Ls []*big.Int, signature *CLSignature) (bool, error) {
 	// each m should be in [0, 2^l_m)
 	for _, m_L := range m_Ls {
 		if m_L.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m)), nil)) > -1 {
-			err := errors.New("msg is too big")	
+			err := errors.New("msg is too big")
 			return false, err
 		}
 	}
-	
+
 	// check v^e = a^m*b^s*c (mod n)
 	// and check: 2^l_e - 1 < e < 2^l_e, where l_e = l_m + 2
-	
+
 	/*
-	b1 := signature.e.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m+1)), nil))
-	b2 := signature.e.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m+2)), nil))
-	if (b1 != 1) || (b2 != -1) {
-		return false, nil
-	}
+		b1 := signature.e.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m+1)), nil))
+		b2 := signature.e.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m+2)), nil))
+		if (b1 != 1) || (b2 != -1) {
+			return false, nil
+		}
 	*/
-	
+
 	numOfBlocks := len(m_Ls)
 	a := new(big.Int)
 	for i := 0; i < numOfBlocks; i++ {
 		a = new(big.Int).Exp(cl.pubKey.a_L[i], m_Ls[i], cl.pubKey.n)
-    }
-     	
+	}
+
 	t2 := new(big.Int).Exp(cl.pubKey.b, signature.s, cl.pubKey.n) // b^s
 	t := new(big.Int).Mul(a, t2)
-	t = new(big.Int).Mul(t, cl.pubKey.c) // a^m * b^s * c 
+	t = new(big.Int).Mul(t, cl.pubKey.c) // a^m * b^s * c
 	t = new(big.Int).Mod(t, cl.pubKey.n) // a^m * b^s * c % n
-	
-	ve := new(big.Int).Exp(signature.v, signature.e, cl.pubKey.n) // v^e 
-	ve = new(big.Int).Mod(ve, cl.pubKey.n) // v^e % n
-	
+
+	ve := new(big.Int).Exp(signature.v, signature.e, cl.pubKey.n) // v^e
+	ve = new(big.Int).Mod(ve, cl.pubKey.n)                        // v^e % n
+
 	if ve.Cmp(t) == 0 {
 		return true, nil
 	} else {
@@ -201,16 +201,11 @@ func (cl *CL) generateKey() (err error) {
 	a_L, b, c := cl.getQuadraticResidues(n)
 	cl.p = p
 	cl.q = q
-	cl.pubKey = &CLPubKey {
-		n: n,
+	cl.pubKey = &CLPubKey{
+		n:   n,
 		a_L: a_L,
-		b: b,
-		c: c,
+		b:   b,
+		c:   c,
 	}
 	return nil
 }
-
-
-
-
-

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -1,11 +1,11 @@
 package tests
 
 import (
-	"testing"
-	"github.com/stretchr/testify/assert"	
-	"math/big"
+	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/common"
 	"log"
+	"math/big"
+	"testing"
 )
 
 func TestLCM(t *testing.T) {
@@ -19,7 +19,7 @@ func TestGetGermainPrime(t *testing.T) {
 	p := common.GetGermainPrime(512)
 	p1 := new(big.Int).Add(p, p)
 	p1.Add(p1, big.NewInt(1))
-	
+
 	assert.Equal(t, p.ProbablyPrime(20), true, "p should be prime")
 	assert.Equal(t, p1.ProbablyPrime(20), true, "p1 should be prime")
 }
@@ -32,7 +32,7 @@ func TestGetSafePrime(t *testing.T) {
 	p1 := new(big.Int)
 	p1.Sub(p, big.NewInt(1))
 	p1.Div(p1, big.NewInt(2))
-	
+
 	assert.Equal(t, p.ProbablyPrime(20), true, "p should be prime")
 	assert.Equal(t, p1.ProbablyPrime(20), true, "p1 should be prime")
 }
@@ -42,33 +42,33 @@ func TestGeneratorOfCompositeQR(t *testing.T) {
 	q, _ := common.GetSafePrime(512)
 	g, _ := common.GetGeneratorOfCompositeQR(p, q)
 	n := new(big.Int).Mul(p, q)
-	    	
+
 	p1 := new(big.Int)
 	p1.Sub(p, big.NewInt(1))
 	p1.Div(p1, big.NewInt(2))
 	q1 := new(big.Int)
 	q1.Sub(q, big.NewInt(1))
 	q1.Div(q1, big.NewInt(2))
-	
+
 	// order of g should be 2*p1*q1
 	order := new(big.Int).Mul(p1, q1)
 	order.Mul(order, big.NewInt(2))
 	tmp := new(big.Int).Exp(g, order, n)
-	
+
 	assert.Equal(t, tmp, big.NewInt(1), "g is not a generator")
 	// other possible orders in this group are: 2, p1, q1, 2 * p1, and 2 * q1.
 	tmp = new(big.Int).Exp(g, big.NewInt(2), n)
 	assert.NotEqual(t, tmp, big.NewInt(1), "g is not a generator")
-	
+
 	tmp = new(big.Int).Exp(g, p1, n)
 	assert.NotEqual(t, tmp, big.NewInt(1), "g is not a generator")
-	
+
 	tmp = new(big.Int).Exp(g, q1, n)
 	assert.NotEqual(t, tmp, big.NewInt(1), "g is not a generator")
-	
+
 	tmp = new(big.Int).Exp(g, q1.Mul(p1, big.NewInt(2)), n)
 	assert.NotEqual(t, tmp, big.NewInt(1), "g is not a generator")
-	
+
 	tmp = new(big.Int).Exp(g, q1.Mul(q1, big.NewInt(2)), n)
 	assert.NotEqual(t, tmp, big.NewInt(1), "g is not a generator")
 }
@@ -87,9 +87,6 @@ func TestGetGeneratorOfZnSubgroup(t *testing.T) {
 		log.Println(err)
 	}
 	g.Exp(g, big.NewInt(0).Sub(p1, big.NewInt(1)), p1) // g^(p1-1) % p1 should be 1
-	
+
 	assert.Equal(t, g, big.NewInt(1), "not a generator")
 }
-
-
-

--- a/test/encryption_test.go
+++ b/test/encryption_test.go
@@ -2,32 +2,32 @@ package tests
 
 import (
 	"github.com/stretchr/testify/assert"
-	"github.com/xlab-si/emmy/encryption"
 	"github.com/xlab-si/emmy/common"
 	"github.com/xlab-si/emmy/config"
+	"github.com/xlab-si/emmy/encryption"
 	"math/big"
 	"path/filepath"
 	"testing"
 )
 
 func TestPaillier(t *testing.T) {
-	paillier := encryption.NewPaillier(1024)	
+	paillier := encryption.NewPaillier(1024)
 	pubKey := paillier.GetPubKey()
-	
+
 	m := common.GetRandomInt(big.NewInt(123412341234123))
 	pubPaillier := encryption.NewPubPaillier(pubKey)
 	c, _ := pubPaillier.Encrypt(m)
 	p, _ := paillier.Decrypt(c)
-	
+
 	assert.Equal(t, m, p, "Paillier encryption/decryption does not work correctly")
 }
 
 func TestCSPaillier(t *testing.T) {
-	secParams := encryption.CSPaillierSecParams {
-		L: 512,
+	secParams := encryption.CSPaillierSecParams{
+		L:        512,
 		RoLength: 160,
-		K: 158,
-		K1: 158,
+		K:        158,
+		K1:       158,
 	}
 
 	dir := config.LoadTestKeyDirFromConfig()
@@ -37,18 +37,15 @@ func TestCSPaillier(t *testing.T) {
 	cspaillier := encryption.NewCSPaillier(&secParams)
 	cspaillier.StoreSecKey(secKeyPath)
 	cspaillier.StorePubKey(pubKeyPath)
-	
+
 	cspaillierPub, _ := encryption.NewCSPaillierFromPubKeyFile(pubKeyPath)
-	
+
 	m := common.GetRandomInt(big.NewInt(8685849))
 	label := common.GetRandomInt(big.NewInt(340002223232))
 	u, e, v, _ := cspaillierPub.Encrypt(m, label)
-	
+
 	cspaillierSec, _ := encryption.NewCSPaillierFromSecKey(secKeyPath)
 	p, _ := cspaillierSec.Decrypt(u, e, v, label)
-	
+
 	assert.Equal(t, m, p, "Camenisch-Shoup modified Paillier encryption/decryption does not work correctly")
 }
-
-
-

--- a/test/signatures_test.go
+++ b/test/signatures_test.go
@@ -1,11 +1,11 @@
 package tests
 
 import (
-	"testing"
-	"math/big"
-	"github.com/xlab-si/emmy/signatures"
 	"github.com/xlab-si/emmy/common"
+	"github.com/xlab-si/emmy/signatures"
 	"log"
+	"math/big"
+	"testing"
 )
 
 func TestCL(t *testing.T) {
@@ -13,24 +13,20 @@ func TestCL(t *testing.T) {
 	cl := signatures.NewCL(numOfBlocks)
 	n := new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(160)), nil)
 	//n, _ := new(big.Int).SetString("26959946667150639794667015087019630673557916260026308143510066298881", 10)
-	
+
 	m1 := common.GetRandomInt(n)
 	m2 := common.GetRandomInt(n)
 	var m_Ls []*big.Int
 	m_Ls = append(m_Ls, m1)
 	m_Ls = append(m_Ls, m2)
-	
+
 	signature, err := cl.Sign(m_Ls)
 	if err != nil {
 		log.Println(err)
-	}	
-	
+	}
+
 	pubKey := cl.GetPubKey()
 	pubCL := signatures.NewPubCL(pubKey)
 	ok, _ := pubCL.Verify(m_Ls, signature)
 	log.Println(ok)
 }
-
-
-
-


### PR DESCRIPTION
Until now, some of the individual `.go` files have already been go-formatted with the
`gofmt` tool, but most of them were not. Commit in this PR applies go formatting to the
entire go code base in order to keep the formatting clean and consistent.