### PR TITLE
Enable log suppression

### DIFF
--- a/log/logging.go
+++ b/log/logging.go
@@ -2,6 +2,9 @@ package log
 
 import "github.com/op/go-logging"
 
+var clientModule = "client"
+var serverModule = "server"
+
 var longFormat = logging.MustStringFormatter(
 	`%{color}[%{module}] %{time:15:04:05.000} %{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
 )
@@ -16,4 +19,11 @@ func init() {
 	ClientLogger = logging.MustGetLogger("client")
 	ServerLogger = logging.MustGetLogger("server")
 	logging.SetFormatter(longFormat)
+}
+
+// TurnOffLogging sets the log level to -1, causing logs not to be printed to stdout.
+// This is useful to avoid otherwise verbose logging during benchmarks
+func TurnOff() {
+	logging.SetLevel(-1, clientModule)
+	logging.SetLevel(-1, serverModule)
 }


### PR DESCRIPTION
This commit adds a TurnOff function to emmy's logging package. The function
is useful for suppressing otherwise intentionally verbose logging, which is not 
always desired (for instance, when running tests or benchmarks).