### PR TITLE
Minor refactoring of test package

### DIFF
--- a/test/common_test.go
+++ b/test/common_test.go
@@ -1,4 +1,4 @@
-package tests
+package test
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/test/communication_test.go
+++ b/test/communication_test.go
@@ -1,4 +1,4 @@
-package tests
+package test
 
 import (
 	"github.com/stretchr/testify/assert"
@@ -13,7 +13,7 @@ import (
 	"testing"
 )
 
-var testGrpcServerEndpont = "localhost:7008"
+var testGrpcServerEndpoint = "localhost:7008"
 
 // TestMain is run implicitly and only once, before any of the tests defined in this file run.
 // It fires up a test gRPC server in a goroutine, runs all the tests in this file, then stops
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 
 func testPedersen(n *big.Int) error {
 	dlog := config.LoadDLog("pedersen")
-	c, err := client.NewPedersenClient(testGrpcServerEndpont, pb.SchemaVariant_SIGMA, dlog, n)
+	c, err := client.NewPedersenClient(testGrpcServerEndpoint, pb.SchemaVariant_SIGMA, dlog, n)
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func testPedersen(n *big.Int) error {
 }
 
 func testPedersenEC(n *big.Int) error {
-	c, err := client.NewPedersenECClient(testGrpcServerEndpont, n)
+	c, err := client.NewPedersenECClient(testGrpcServerEndpoint, n)
 	if err != nil {
 		return err
 	}
@@ -45,7 +45,7 @@ func testPedersenEC(n *big.Int) error {
 
 func testSchnorr(n *big.Int, variant pb.SchemaVariant) error {
 	dlog := config.LoadDLog("schnorr")
-	c, err := client.NewSchnorrClient(testGrpcServerEndpont, variant, dlog, n)
+	c, err := client.NewSchnorrClient(testGrpcServerEndpoint, variant, dlog, n)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func testSchnorr(n *big.Int, variant pb.SchemaVariant) error {
 }
 
 func testSchnorrEC(n *big.Int, variant pb.SchemaVariant) error {
-	c, err := client.NewSchnorrECClient(testGrpcServerEndpont, variant, dlog.P256, n)
+	c, err := client.NewSchnorrECClient(testGrpcServerEndpoint, variant, dlog.P256, n)
 	if err != nil {
 		return err
 	}
@@ -80,7 +80,7 @@ func TestGRPC_Dlogproofs(t *testing.T) {
 }
 
 func testCSPaillier(m, l *big.Int, pubKeyPath string) error {
-	c, err := client.NewCSPaillierClient(testGrpcServerEndpont, pubKeyPath, m, l)
+	c, err := client.NewCSPaillierClient(testGrpcServerEndpoint, pubKeyPath, m, l)
 	if err != nil {
 		return err
 	}

--- a/test/dlog_test.go
+++ b/test/dlog_test.go
@@ -1,4 +1,4 @@
-package tests
+package test
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/test/encryption_test.go
+++ b/test/encryption_test.go
@@ -1,4 +1,4 @@
-package tests
+package test
 
 import (
 	"github.com/stretchr/testify/assert"

--- a/test/pseudonymsys_ec_test.go
+++ b/test/pseudonymsys_ec_test.go
@@ -1,4 +1,4 @@
-package tests
+package test
 
 import (
 	"github.com/stretchr/testify/assert"
@@ -13,7 +13,7 @@ import (
 
 func TestPseudonymsysEC(t *testing.T) {
 	dlog := dlog.NewECDLog(dlog.P256)
-	caClient, err := client.NewPseudonymsysCAClientEC(testGrpcServerEndpont)
+	caClient, err := client.NewPseudonymsysCAClientEC(testGrpcServerEndpoint)
 	if err != nil {
 		t.Errorf("Error when initializing NewPseudonymsysCAClientEC")
 	}
@@ -31,7 +31,7 @@ func TestPseudonymsysEC(t *testing.T) {
 	}
 
 	// usually the endpoint is different from the one used for CA:
-	c1, err := client.NewPseudonymsysClientEC(testGrpcServerEndpont)
+	c1, err := client.NewPseudonymsysClientEC(testGrpcServerEndpoint)
 	nym1, err := c1.GenerateNym(userSecret, caCertificate)
 	if err != nil {
 		t.Errorf(err.Error())
@@ -49,13 +49,13 @@ func TestPseudonymsysEC(t *testing.T) {
 
 	// register with org2
 	// create a client to communicate with org2
-	caClient1, err := client.NewPseudonymsysCAClientEC(testGrpcServerEndpont)
+	caClient1, err := client.NewPseudonymsysCAClientEC(testGrpcServerEndpoint)
 	caCertificate1, err := caClient1.ObtainCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA")
 	}
 
-	c2, err := client.NewPseudonymsysClientEC(testGrpcServerEndpont)
+	c2, err := client.NewPseudonymsysClientEC(testGrpcServerEndpoint)
 	nym2, err := c2.GenerateNym(userSecret, caCertificate1)
 	if err != nil {
 		t.Errorf(err.Error())

--- a/test/pseudonymsys_test.go
+++ b/test/pseudonymsys_test.go
@@ -1,4 +1,4 @@
-package tests
+package test
 
 import (
 	"github.com/stretchr/testify/assert"
@@ -11,7 +11,7 @@ import (
 // TestPseudonymsys requires a running server (it is started in communication_test.go).
 func TestPseudonymsys(t *testing.T) {
 	dlog := config.LoadDLog("pseudonymsys")
-	caClient, err := client.NewPseudonymsysCAClient(testGrpcServerEndpont)
+	caClient, err := client.NewPseudonymsysCAClient(testGrpcServerEndpoint)
 	if err != nil {
 		t.Errorf("Error when initializing NewPseudonymsysCAClient")
 	}
@@ -26,7 +26,7 @@ func TestPseudonymsys(t *testing.T) {
 	}
 
 	// usually the endpoint is different from the one used for CA:
-	c1, err := client.NewPseudonymsysClient(testGrpcServerEndpont)
+	c1, err := client.NewPseudonymsysClient(testGrpcServerEndpoint)
 	nym1, err := c1.GenerateNym(userSecret, caCertificate)
 	if err != nil {
 		t.Errorf(err.Error())
@@ -42,13 +42,13 @@ func TestPseudonymsys(t *testing.T) {
 
 	// register with org2
 	// create a client to communicate with org2
-	caClient1, err := client.NewPseudonymsysCAClient(testGrpcServerEndpont)
+	caClient1, err := client.NewPseudonymsysCAClient(testGrpcServerEndpoint)
 	caCertificate1, err := caClient1.ObtainCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA")
 	}
 
-	c2, err := client.NewPseudonymsysClient(testGrpcServerEndpont)
+	c2, err := client.NewPseudonymsysClient(testGrpcServerEndpoint)
 	nym2, err := c2.GenerateNym(userSecret, caCertificate1)
 	if err != nil {
 		t.Errorf(err.Error())

--- a/test/signatures_test.go
+++ b/test/signatures_test.go
@@ -1,4 +1,4 @@
-package tests
+package test
 
 import (
 	"github.com/xlab-si/emmy/common"


### PR DESCRIPTION
This commit renames the package with unit tests to 'test', like the parent folder. It also removes a typo in the name of a global variable.

This is not refactoring of logic per-se, only a couple of really minor changes that need to be taken care of before proceeding with further changes in the package with unit tests.