### PR TITLE
Create gRPC connections outside protocol clients

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -14,31 +14,40 @@ import (
 
 var logger = log.ClientLogger
 
-type genericClient struct {
-	id     int32
-	conn   *grpc.ClientConn
-	stream pb.Protocol_RunClient
+// GetConnection attempts to return a connection to a gRPC server at a given endpoint.
+// Note that several clients can be passed the same connection object, as the gRPC framework
+// is able to multiplex several RPCs on the same connection, thus reducing the overhead
+func GetConnection(serverEndpoint string) (*grpc.ClientConn, error) {
+	logger.Debug("Getting the connection")
+	timeoutSec := config.LoadTimeout()
+	dialOptions := []grpc.DialOption{
+		// TODO enable secure connection to gRPC server
+		grpc.WithInsecure(),
+		grpc.WithBlock(),
+		grpc.WithTimeout(time.Duration(timeoutSec) * time.Second),
+	}
+	conn, err := grpc.Dial(serverEndpoint, dialOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("Could not connect to server %v (%v)", serverEndpoint, err)
+	}
+	return conn, nil
 }
 
-func newGenericClient(endpoint string) (*genericClient, error) {
-	conn, err := getConnection(endpoint)
-	if err != nil {
-		return nil, err
-	}
+type genericClient struct {
+	id             int32
+	protocolClient pb.ProtocolClient
+	stream         pb.Protocol_RunClient
+}
 
+func newGenericClient(conn *grpc.ClientConn) (*genericClient, error) {
 	logger.Debug("Creating the client")
 	client := pb.NewProtocolClient(conn)
-	stream, err := getStream(client)
-	if err != nil {
-		return nil, err
-	}
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
 	genClient := genericClient{
-		id:     rand.Int31(),
-		conn:   conn,
-		stream: stream,
+		id:             rand.Int31(),
+		protocolClient: client,
 	}
 
 	logger.Infof("New GenericClient spawned (%v)", genClient.id)
@@ -76,37 +85,27 @@ func (c *genericClient) getResponseTo(msg *pb.Message) (*pb.Message, error) {
 	return c.receive()
 }
 
-// close closes the communication stream and connection to the server.
-func (c *genericClient) close() error {
-	if err := c.stream.CloseSend(); err != nil {
-		return fmt.Errorf("[Client %v] Error closing stream: %v", c.id, err)
+// openStream opens the gRPC communication stream with the server prior to actual execution of
+// the protocol client.
+// This function has to be called explicitly at the beginning of the protocol execution function.
+func (c *genericClient) openStream() error {
+	stream, err := c.protocolClient.Run(context.Background())
+	if err != nil {
+		return fmt.Errorf("[Client %v] Error opening stream: %v", c.id, err)
 	}
-	if err := c.conn.Close(); err != nil {
-		return fmt.Errorf("[Client %v] Error closing connection: %v", c.id, err)
-	}
+
+	c.stream = stream
 	return nil
 }
 
-func getConnection(serverEndpoint string) (*grpc.ClientConn, error) {
-	logger.Debug("Getting the connection")
-	timeoutSec := config.LoadTimeout()
-	dialOptions := []grpc.DialOption{
-		grpc.WithInsecure(),
-		grpc.WithBlock(),
-		grpc.WithTimeout(time.Duration(timeoutSec) * time.Second),
+// closeStream closes the gRPC communication stream with the server, indicating the end of
+// a protocol execution.
+// This function has to be called explicitly at the end of protocol execution function.
+// Note that closing the stream does not close the corresponding connection to the server,
+// as it should be done externally.
+func (c *genericClient) closeStream() error {
+	if err := c.stream.CloseSend(); err != nil {
+		return fmt.Errorf("[Client %v] Error closing stream: %v", c.id, err)
 	}
-	conn, err := grpc.Dial(serverEndpoint, dialOptions...)
-	if err != nil {
-		return nil, fmt.Errorf("Could not connect to server %v (%v)", serverEndpoint, err)
-	}
-	return conn, nil
-}
-
-func getStream(client pb.ProtocolClient) (pb.Protocol_RunClient, error) {
-	logger.Debug("Getting the stream")
-	stream, err := client.Run(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("Error creating the stream: %v", err)
-	}
-	return stream, nil
+	return nil
 }

--- a/client/pedersen.go
+++ b/client/pedersen.go
@@ -4,6 +4,7 @@ import (
 	"github.com/xlab-si/emmy/commitments"
 	"github.com/xlab-si/emmy/dlog"
 	pb "github.com/xlab-si/emmy/protobuf"
+	"google.golang.org/grpc"
 	"math/big"
 )
 
@@ -14,9 +15,9 @@ type PedersenClient struct {
 }
 
 // NewPedersenClient returns an initialized struct of type PedersenClient.
-func NewPedersenClient(endpoint string, variant pb.SchemaVariant, dlog *dlog.ZpDLog,
+func NewPedersenClient(conn *grpc.ClientConn, variant pb.SchemaVariant, dlog *dlog.ZpDLog,
 	val *big.Int) (*PedersenClient, error) {
-	genericClient, err := newGenericClient(endpoint)
+	genericClient, err := newGenericClient(conn)
 	if err != nil {
 		return nil, err
 	}
@@ -32,6 +33,9 @@ func NewPedersenClient(endpoint string, variant pb.SchemaVariant, dlog *dlog.ZpD
 
 // Run runs Pedersen commitment protocol in multiplicative group of integers modulo p.
 func (c *PedersenClient) Run() error {
+	c.openStream()
+	defer c.closeStream()
+
 	pf, err := c.getH()
 	if err != nil {
 		return err
@@ -55,9 +59,6 @@ func (c *PedersenClient) Run() error {
 		return err
 	}
 
-	if err := c.close(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/client/pedersen_ec.go
+++ b/client/pedersen_ec.go
@@ -4,6 +4,7 @@ import (
 	"github.com/xlab-si/emmy/commitments"
 	"github.com/xlab-si/emmy/common"
 	pb "github.com/xlab-si/emmy/protobuf"
+	"google.golang.org/grpc"
 	"math/big"
 )
 
@@ -14,8 +15,8 @@ type PedersenECClient struct {
 }
 
 // NewPedersenECClient returns an initialized struct of type PedersenECClient.
-func NewPedersenECClient(endpoint string, v *big.Int) (*PedersenECClient, error) {
-	genericClient, err := newGenericClient(endpoint)
+func NewPedersenECClient(conn *grpc.ClientConn, v *big.Int) (*PedersenECClient, error) {
+	genericClient, err := newGenericClient(conn)
 	if err != nil {
 		return nil, err
 	}
@@ -29,6 +30,9 @@ func NewPedersenECClient(endpoint string, v *big.Int) (*PedersenECClient, error)
 
 // Run runs Pedersen commitment protocol in the eliptic curve group.
 func (c *PedersenECClient) Run() error {
+	c.openStream()
+	defer c.closeStream()
+
 	ecge, err := c.getH()
 	if err != nil {
 		return err
@@ -51,9 +55,6 @@ func (c *PedersenECClient) Run() error {
 		return err
 	}
 
-	if err := c.close(); err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/test/pseudonymsys_ec_test.go
+++ b/test/pseudonymsys_ec_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPseudonymsysEC(t *testing.T) {
 	dlog := dlog.NewECDLog(dlog.P256)
-	caClient, err := client.NewPseudonymsysCAClientEC(testGrpcServerEndpoint)
+	caClient, err := client.NewPseudonymsysCAClientEC(testGrpcClientConn)
 	if err != nil {
 		t.Errorf("Error when initializing NewPseudonymsysCAClientEC")
 	}
@@ -31,7 +31,7 @@ func TestPseudonymsysEC(t *testing.T) {
 	}
 
 	// usually the endpoint is different from the one used for CA:
-	c1, err := client.NewPseudonymsysClientEC(testGrpcServerEndpoint)
+	c1, err := client.NewPseudonymsysClientEC(testGrpcClientConn)
 	nym1, err := c1.GenerateNym(userSecret, caCertificate)
 	if err != nil {
 		t.Errorf(err.Error())
@@ -49,13 +49,13 @@ func TestPseudonymsysEC(t *testing.T) {
 
 	// register with org2
 	// create a client to communicate with org2
-	caClient1, err := client.NewPseudonymsysCAClientEC(testGrpcServerEndpoint)
+	caClient1, err := client.NewPseudonymsysCAClientEC(testGrpcClientConn)
 	caCertificate1, err := caClient1.ObtainCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA")
 	}
 
-	c2, err := client.NewPseudonymsysClientEC(testGrpcServerEndpoint)
+	c2, err := client.NewPseudonymsysClientEC(testGrpcClientConn)
 	nym2, err := c2.GenerateNym(userSecret, caCertificate1)
 	if err != nil {
 		t.Errorf(err.Error())

--- a/test/pseudonymsys_test.go
+++ b/test/pseudonymsys_test.go
@@ -11,7 +11,7 @@ import (
 // TestPseudonymsys requires a running server (it is started in communication_test.go).
 func TestPseudonymsys(t *testing.T) {
 	dlog := config.LoadDLog("pseudonymsys")
-	caClient, err := client.NewPseudonymsysCAClient(testGrpcServerEndpoint)
+	caClient, err := client.NewPseudonymsysCAClient(testGrpcClientConn)
 	if err != nil {
 		t.Errorf("Error when initializing NewPseudonymsysCAClient")
 	}
@@ -26,7 +26,7 @@ func TestPseudonymsys(t *testing.T) {
 	}
 
 	// usually the endpoint is different from the one used for CA:
-	c1, err := client.NewPseudonymsysClient(testGrpcServerEndpoint)
+	c1, err := client.NewPseudonymsysClient(testGrpcClientConn)
 	nym1, err := c1.GenerateNym(userSecret, caCertificate)
 	if err != nil {
 		t.Errorf(err.Error())
@@ -42,13 +42,13 @@ func TestPseudonymsys(t *testing.T) {
 
 	// register with org2
 	// create a client to communicate with org2
-	caClient1, err := client.NewPseudonymsysCAClient(testGrpcServerEndpoint)
+	caClient1, err := client.NewPseudonymsysCAClient(testGrpcClientConn)
 	caCertificate1, err := caClient1.ObtainCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA")
 	}
 
-	c2, err := client.NewPseudonymsysClient(testGrpcServerEndpoint)
+	c2, err := client.NewPseudonymsysClient(testGrpcClientConn)
 	nym2, err := c2.GenerateNym(userSecret, caCertificate1)
 	if err != nil {
 		t.Errorf(err.Error())


### PR DESCRIPTION
This commit moves creation of `*grpc.ClientConn` outside protocol clients. Instead of server `endpoint string`, clients are now passed a connection, which allows us to:
* re-use a single connection across several protocol clients
* reduce some initialization overhead when running tests (and in future benchmarks)
* avoid an issue with exhausted file descriptors in case we are starting too many connections, which occurs when starting thousands of concurrent clients on the same host

Inside main client functions executing crypto protocols, you will notice that once the protocol finishes we are not manipulating (closing) connection anymore, but gRPC streams. E.g., instead of this:

```go
if err := c.close(); err != nil { ... } // closes gRPC connection
```

we are now doing:

```go
if err := c.stream.CloseSend(); err != nil { ... } // closes client-side gRPC stream
```

Clients, unit tests and `emmy.go` CLI were all updated accordingly.