### PR TITLE
Add support for controlling log levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The library comes with a convenient CLI for running *emmy server*, *emmy clients
 To get some more information about the theory behind zero knowledge proofs, please refer to additional documentation in the *docs* folder.
 
 #### What does emmy stand for?
-Emmy is named after [Emmy Noether](https://sl.wikipedia.org/wiki/Emmy_Noether).
+Emmy library is named after a German mathematician [Emmy Noether](https://en.wikipedia.org/wiki/Emmy_Noether), recognised as one of the most important 20th century mathematicians. Emmy Noether's groundbreaking work in the field of abstract algebra earned her a nickname *the mother of modern algebra*. We named our library after her, since modern cryptography generally relies heavily on abstract algebraic structures and concepts.
 
 # Installation
 To install emmy, run 
@@ -30,10 +30,19 @@ Below we provide isntructions for using the `emmy` CLI tool. In addition, you ca
 ## Emmy server
 Emmy server waits for requests from clients (provers) and starts verifying them.
 
+```bash
+$ emmy server        # prints available commands, options and default values
+$ emmy server start  # starts emmy server with default settings
 ```
-$ emmy server        # prints help
-$ emmy server start  # starts emmy server
+
+Alternatively, to control what gets logged server-side, you can provide the flag `--loglevel` (shorthand `-l`) with one of the values `debug|info|notice|error|critical`. For instance, for development or debugging purposes we might prefer more fine-grained logs, in which case we would run
+
+
+```bash
+$ emmy server start --loglevel debug # or shorthand '-l debug'
 ```
+
+If this flag is omitted, the log level defaults to `info`.
 
 Starting the server should produce an output similar to the one below:
 
@@ -57,8 +66,9 @@ Running the clients requires an instance of emmy server. First, spin up the emmy
 1. **Which protocol to run**: flags *--protocol* (shorthand *-p*) which must be one of `pedersen|pedersen_ec|schnorr|schnorr_ec|cspaillier` and defaults to pedersen, and flag *--variant* (shorthand *-v*) which must be one of `sigma|zkp|zkpok` and defaults to sigma. 
 2. **How many clients to start**: flag *--nclients* (shorthand *-n*), defaults to 1.
 3. **Whether to run clients concurrently or not**: flag *--concurrent*. Include this flag if you want to run the specified number of clients consurrently. The absence of this flag means that clients will be run sequentially.
+4. **Logging level**: flag *--loglevel* (shorthand *-l*), which must be one of `debug|info|notice|error|critical`. Defaults to `ìnfo`.
 
-You can also list these flags by running `emmy client --help`.
+You can also list these flags and their default values by running `emmy client --help`.
 
 Here are some equivalent examples:
 ```
@@ -147,14 +157,6 @@ Currently supported crypto primitives with fully implemented communication layer
 # Documentation
 * [A short overview of the theory Emmy is based on](./docs/theory.md) 
 * [Developing Emmy (draft)](./docs/develop.md) 
-
-# Roadmap
-* Implement newer schemes for anonymous credentials
-* Enable ZKP & ZKPOK for CSPailier
-* Implement communication layer for latest protocols
-* Reorganize library - divide client, server, core (to be decided)
-* Benchmarks
-* ...
 
 # References
 

--- a/emmy.go
+++ b/emmy.go
@@ -35,19 +35,31 @@ func main() {
 	// protocol type and variant to demonstrate
 	var protocolType, protocolVariant string
 
+	// log level applied to client/server loggers
+	var logLevel string
+
 	app := cli.NewApp()
 	app.Name = "emmy"
 	app.Version = "0.1"
 	app.Usage = "A CLI app for running emmy server, emmy clients and examples of proofs offered by the emmy library"
 
+	logLevelFlag := cli.StringFlag{
+		Name:        "loglevel, l",
+		Value:       "info",
+		Usage:       "debug|info|notice|error|critical",
+		Destination: &logLevel,
+	}
+
 	serverApp := cli.Command{
 		Name:  "server",
 		Usage: "A server that verifies clients (provers)",
+		Flags: []cli.Flag{logLevelFlag},
 		Subcommands: []cli.Command{
 			{
 				Name:  "start",
 				Usage: "Starts emmy server",
 				Action: func(c *cli.Context) error {
+					server.SetLogLevel(logLevel)
 					startEmmyServer()
 					return nil
 				},
@@ -77,12 +89,14 @@ func main() {
 			Name:        "concurrent",
 			Destination: &runConcurrently,
 		},
+		logLevelFlag,
 	}
 	clientApp := cli.Command{
 		Name:  "client",
 		Usage: "A client that wants to prove something to the verifier (server)",
 		Flags: clientFlags,
 		Action: func(ctx *cli.Context) error {
+			client.SetLogLevel(logLevel)
 			runClients(n, runConcurrently, protocolType, protocolVariant, emmyServerEndpoint)
 			return nil
 		},
@@ -94,6 +108,8 @@ func main() {
 		Runs both emmy server as well as client(s).`,
 		Flags: clientFlags,
 		Action: func(ctx *cli.Context) error {
+			client.SetLogLevel(logLevel)
+			server.SetLogLevel(logLevel)
 			go startEmmyServer()
 			runClients(n, runConcurrently, protocolType, protocolVariant, emmyServerEndpoint)
 			return nil

--- a/log/logging.go
+++ b/log/logging.go
@@ -13,17 +13,49 @@ var shortFormat = logging.MustStringFormatter(
 	`%{color}%{shortfunc} ▶ %{level:.4s} %{id:03x}%{color:reset} %{message}`,
 )
 
-var ClientLogger, ServerLogger *logging.Logger
+// Expose two per-package loggers, one for client side, one for server side
+var ClientLogger, ServerLogger *Logger
 
+// Logger is a convenience wrapper struct that embeds go-logging logger.
+// We use it for easier configuration of log levels
+type Logger struct {
+	*logging.Logger
+}
+
+func newLogger(module string) *Logger {
+	return &Logger{
+		logging.MustGetLogger(module),
+	}
+}
+
+// init instantiates and configures client and server loggers with the default format and
+// log level.
 func init() {
-	ClientLogger = logging.MustGetLogger("client")
-	ServerLogger = logging.MustGetLogger("server")
+	ClientLogger = newLogger(clientModule)
+	ServerLogger = newLogger(serverModule)
+	ClientLogger.SetLevel("info")
+	ServerLogger.SetLevel("info")
 	logging.SetFormatter(longFormat)
 }
 
-// TurnOffLogging sets the log level to -1, causing logs not to be printed to stdout.
-// This is useful to avoid otherwise verbose logging during benchmarks
+// SetLevel sets the log level for the given logger. In case of an invalid log level argument,
+// it propagates the error detected by go-logging's package logging
+func (logger *Logger) SetLevel(level string) error {
+	// obtain logging.Level type from a string argument representing log level
+	levelInt, err := logging.LogLevel(level)
+	if err != nil {
+		return err
+	}
+
+	logging.SetLevel(levelInt, logger.Module)
+	return nil
+}
+
+// TurnOff sets the log level of server and client loggers to -1, causing logs not to
+// be printed to stdout. This is useful to avoid otherwise verbose logging during benchmarks
+// It would be better to use Logger's SetLevel function, but it accepts only a supported set of
+// string argument, so the '-1' log level cannot be correctly represented
 func TurnOff() {
-	logging.SetLevel(-1, clientModule)
-	logging.SetLevel(-1, serverModule)
+	logging.SetLevel(-1, ClientLogger.Module)
+	logging.SetLevel(-1, ServerLogger.Module)
 }

--- a/test/communication_test.go
+++ b/test/communication_test.go
@@ -24,6 +24,10 @@ var testGrpcClientConn *grpc.ClientConn
 // connection is then re-used in all the tests to reduce overhead.
 // Once all the tests run, we close the connection to the server and stop the server.
 func TestMain(m *testing.M) {
+	// Set debug log level for easier troubleshooting in case something goes wrong
+	client.SetLogLevel("debug")
+	server.SetLogLevel("debug")
+
 	server := server.NewProtocolServer()
 	go server.Start(7008)
 


### PR DESCRIPTION
In this commit we modify the `logging` package in order to be more conveniently used by other (mainly `client`, `server` and `test`) packages. The default log level set by logging package's `init()` function is *info*. However for tests, we're now explicitly setting the loglevel to *debug*. The log levels are standard ones, e.g. *debug*, *info*, *notice*, *error* and *critical*.

The loglevel flag was also added to emmy CLI in order to give the end user some more control. The end user interacting with the CLI app can now control the log level like this:

````bash
$ emmy example --loglevel notice  # or '-l notice'
$ emmy server start --loglevel info # we can omit this, as info is the default log level
$ emmy client --protocol schnorr -l debug
````
I didn't  update the CLI app usage instructions in the README - I can add it to this PR, or, alternatively, do in the near future in a separate PR.

In addition, appropriate changes allowing separation of what gets logged in, for instance, *info* and *debug* log levels, were applied to logging calls in `client/client.go` and `server/server.go`. Specifically, you will notice that the payloads of protobuf messages (which were making the logs a bit messy and harder to read) only get logged if we choose the *debug* log level. 