### PR TITLE
Remove config loading from crypto/pseudonymsys

### DIFF
--- a/crypto/pseudonymsys/ca.go
+++ b/crypto/pseudonymsys/ca.go
@@ -5,8 +5,8 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/common"
+	"github.com/xlab-si/emmy/crypto/dlog"
 	"github.com/xlab-si/emmy/crypto/dlogproofs"
 	"github.com/xlab-si/emmy/types"
 	"math/big"
@@ -35,11 +35,7 @@ func NewCACertificate(blindedA, blindedB, r, s *big.Int) *CACertificate {
 	}
 }
 
-func NewCA() *CA {
-	dlog := config.LoadDLog("pseudonymsys")
-	x, y := config.LoadPseudonymsysCAPubKey()
-	d := config.LoadPseudonymsysCASecret()
-
+func NewCA(dlog *dlog.ZpDLog, d, x, y *big.Int) *CA {
 	c := elliptic.P256()
 	pubKey := ecdsa.PublicKey{Curve: c, X: x, Y: y}
 	privateKey := ecdsa.PrivateKey{PublicKey: pubKey, D: d}

--- a/crypto/pseudonymsys/ca_ec.go
+++ b/crypto/pseudonymsys/ca_ec.go
@@ -5,7 +5,6 @@ import (
 	"crypto/elliptic"
 	"crypto/rand"
 	"fmt"
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/dlog"
 	"github.com/xlab-si/emmy/crypto/dlogproofs"
@@ -37,10 +36,7 @@ func NewCACertificateEC(blindedA, blindedB *types.ECGroupElement, r, s *big.Int)
 	}
 }
 
-func NewCAEC() *CAEC {
-	x, y := config.LoadPseudonymsysCAPubKey()
-	d := config.LoadPseudonymsysCASecret()
-
+func NewCAEC(d, x, y *big.Int) *CAEC {
 	c := elliptic.P256()
 	pubKey := ecdsa.PublicKey{Curve: c, X: x, Y: y}
 	privateKey := ecdsa.PrivateKey{PublicKey: pubKey, D: d}

--- a/crypto/pseudonymsys/org_issue.go
+++ b/crypto/pseudonymsys/org_issue.go
@@ -2,7 +2,6 @@ package pseudonymsys
 
 import (
 	"errors"
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/dlog"
 	"github.com/xlab-si/emmy/crypto/dlogproofs"
 	"github.com/xlab-si/emmy/types"
@@ -56,11 +55,7 @@ type OrgCredentialIssuer struct {
 	b               *big.Int
 }
 
-func NewOrgCredentialIssuer() *OrgCredentialIssuer {
-	dlog := config.LoadDLog("pseudonymsys")
-	// this presumes that organization's own keys are stored under "org1"
-	s1, s2 := config.LoadPseudonymsysOrgSecrets("org1", "dlog")
-
+func NewOrgCredentialIssuer(dlog *dlog.ZpDLog, s1, s2 *big.Int) *OrgCredentialIssuer {
 	// g1 = a_tilde, t1 = b_tilde,
 	// g2 = a, t2 = b
 	schnorrVerifier := dlogproofs.NewSchnorrVerifier(dlog, types.Sigma)

--- a/crypto/pseudonymsys/org_issue_ec.go
+++ b/crypto/pseudonymsys/org_issue_ec.go
@@ -2,7 +2,6 @@ package pseudonymsys
 
 import (
 	"errors"
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/dlog"
 	"github.com/xlab-si/emmy/crypto/dlogproofs"
 	"github.com/xlab-si/emmy/types"
@@ -55,10 +54,7 @@ type OrgCredentialIssuerEC struct {
 	b               *types.ECGroupElement
 }
 
-func NewOrgCredentialIssuerEC() *OrgCredentialIssuerEC {
-	// this presumes that organization's own keys are stored under "org1"
-	s1, s2 := config.LoadPseudonymsysOrgSecrets("org1", "ecdlog")
-
+func NewOrgCredentialIssuerEC(s1, s2 *big.Int) *OrgCredentialIssuerEC {
 	// g1 = a_tilde, t1 = b_tilde,
 	// g2 = a, t2 = b
 	schnorrVerifier := dlogproofs.NewSchnorrECVerifier(dlog.P256, types.Sigma)

--- a/crypto/pseudonymsys/org_nym_gen_ec.go
+++ b/crypto/pseudonymsys/org_nym_gen_ec.go
@@ -4,7 +4,6 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"fmt"
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/dlog"
 	"github.com/xlab-si/emmy/crypto/dlogproofs"
@@ -26,21 +25,24 @@ func NewPseudonymEC(a, b *types.ECGroupElement) *PseudonymEC {
 
 type OrgNymGenEC struct {
 	EqualityVerifier *dlogproofs.ECDLogEqualityVerifier
+	x                *big.Int
+	y                *big.Int
 }
 
-func NewOrgNymGenEC() *OrgNymGenEC {
+func NewOrgNymGenEC(x, y *big.Int) *OrgNymGenEC {
 	verifier := dlogproofs.NewECDLogEqualityVerifier(dlog.P256)
 	org := OrgNymGenEC{
 		EqualityVerifier: verifier,
+		x:                x,
+		y:                y,
 	}
 	return &org
 }
 
 func (org *OrgNymGenEC) GetChallenge(nymA, blindedA, nymB, blindedB,
 	x1, x2 *types.ECGroupElement, r, s *big.Int) (*big.Int, error) {
-	x, y := config.LoadPseudonymsysCAPubKey()
 	c := elliptic.P256()
-	pubKey := ecdsa.PublicKey{Curve: c, X: x, Y: y}
+	pubKey := ecdsa.PublicKey{Curve: c, X: org.x, Y: org.y}
 
 	hashed := common.HashIntoBytes(blindedA.X, blindedA.Y, blindedB.X, blindedB.Y)
 	verified := ecdsa.Verify(&pubKey, hashed, r, s)

--- a/crypto/pseudonymsys/org_transfer.go
+++ b/crypto/pseudonymsys/org_transfer.go
@@ -1,7 +1,6 @@
 package pseudonymsys
 
 import (
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/dlog"
 	"github.com/xlab-si/emmy/crypto/dlogproofs"
 	"math/big"
@@ -17,11 +16,7 @@ type OrgCredentialVerifier struct {
 	b                *big.Int
 }
 
-func NewOrgCredentialVerifier() *OrgCredentialVerifier {
-	dlog := config.LoadDLog("pseudonymsys")
-	// this presumes that organization's own keys are stored under "org1"
-	s1, s2 := config.LoadPseudonymsysOrgSecrets("org1", "dlog")
-
+func NewOrgCredentialVerifier(dlog *dlog.ZpDLog, s1, s2 *big.Int) *OrgCredentialVerifier {
 	equalityVerifier := dlogproofs.NewDLogEqualityVerifier(dlog)
 	org := OrgCredentialVerifier{
 		DLog:             dlog,

--- a/crypto/pseudonymsys/org_transfer_ec.go
+++ b/crypto/pseudonymsys/org_transfer_ec.go
@@ -1,7 +1,6 @@
 package pseudonymsys
 
 import (
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/dlog"
 	"github.com/xlab-si/emmy/crypto/dlogproofs"
 	"github.com/xlab-si/emmy/types"
@@ -17,10 +16,7 @@ type OrgCredentialVerifierEC struct {
 	b                *types.ECGroupElement
 }
 
-func NewOrgCredentialVerifierEC() *OrgCredentialVerifierEC {
-	// this presumes that organization's own keys are stored under "org1"
-	s1, s2 := config.LoadPseudonymsysOrgSecrets("org1", "ecdlog")
-
+func NewOrgCredentialVerifierEC(s1, s2 *big.Int) *OrgCredentialVerifierEC {
 	equalityVerifier := dlogproofs.NewECDLogEqualityVerifier(dlog.P256)
 	org := OrgCredentialVerifierEC{
 		s1:               s1,

--- a/server/pseudonymsys_ca.go
+++ b/server/pseudonymsys_ca.go
@@ -1,14 +1,19 @@
 package server
 
 import (
+	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"math/big"
 )
 
 func (s *Server) PseudonymsysCA(req *pb.Message, stream pb.Protocol_RunServer) error {
-	ca := pseudonymsys.NewCA()
 	var err error
+
+	dlog := config.LoadDLog("pseudonymsys")
+	d := config.LoadPseudonymsysCASecret()
+	pubKeyX, pubKeyY := config.LoadPseudonymsysCAPubKey()
+	ca := pseudonymsys.NewCA(dlog, d, pubKeyX, pubKeyY)
 
 	sProofRandData := req.GetSchnorrProofRandomData()
 	x := new(big.Int).SetBytes(sProofRandData.X)

--- a/server/pseudonymsys_ca_ec.go
+++ b/server/pseudonymsys_ca_ec.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
@@ -8,8 +9,11 @@ import (
 )
 
 func (s *Server) PseudonymsysCAEC(req *pb.Message, stream pb.Protocol_RunServer) error {
-	ca := pseudonymsys.NewCAEC()
 	var err error
+
+	d := config.LoadPseudonymsysCASecret()
+	pubKeyX, pubKeyY := config.LoadPseudonymsysCAPubKey()
+	ca := pseudonymsys.NewCAEC(d, pubKeyX, pubKeyY)
 
 	sProofRandData := req.GetSchnorrEcProofRandomData()
 	x := types.ToECGroupElement(sProofRandData.X)

--- a/server/pseudonymsys_ec.go
+++ b/server/pseudonymsys_ec.go
@@ -9,7 +9,8 @@ import (
 )
 
 func (s *Server) PseudonymsysGenerateNymEC(req *pb.Message, stream pb.Protocol_RunServer) error {
-	org := pseudonymsys.NewOrgNymGenEC()
+	caPubKeyX, caPubKeyY := config.LoadPseudonymsysCAPubKey()
+	org := pseudonymsys.NewOrgNymGenEC(caPubKeyX, caPubKeyY)
 
 	proofRandData := req.GetPseudonymsysNymGenProofRandomDataEc()
 	x1 := types.ToECGroupElement(proofRandData.X1)
@@ -70,7 +71,8 @@ func (s *Server) PseudonymsysIssueCredentialEC(req *pb.Message, stream pb.Protoc
 	a := types.ToECGroupElement(proofRandData.A)
 	b := types.ToECGroupElement(proofRandData.B)
 
-	org := pseudonymsys.NewOrgCredentialIssuerEC()
+	s1, s2 := config.LoadPseudonymsysOrgSecrets("org1", "ecdlog")
+	org := pseudonymsys.NewOrgCredentialIssuerEC(s1, s2)
 	challenge := org.GetAuthenticationChallenge(a, b, x)
 
 	resp := &pb.Message{
@@ -148,7 +150,9 @@ func (s *Server) PseudonymsysIssueCredentialEC(req *pb.Message, stream pb.Protoc
 }
 
 func (s *Server) PseudonymsysTransferCredentialEC(req *pb.Message, stream pb.Protocol_RunServer) error {
-	org := pseudonymsys.NewOrgCredentialVerifierEC()
+	s1, s2 := config.LoadPseudonymsysOrgSecrets("org1", "ecdlog")
+	org := pseudonymsys.NewOrgCredentialVerifierEC(s1, s2)
+
 	data := req.GetPseudonymsysTransferCredentialDataEc()
 	orgName := data.OrgName
 	x1 := types.ToECGroupElement(data.X1)


### PR DESCRIPTION
Previously `crypto/pseudonymsys` package extensively used config loading directly via `config.LoadSomething()` functions, when all other protocols are loading it from grpc
wrappers. In this commit, config loading was moved from `crypto/pseudonymsys` files to pseudonymsys grpc clients, since it will be easier to improve configuration handling across emmy in future, if crypto backend isn't concerned with it.

I also added public key parameters to `OrgNymGen` and `OrgNymGenEC` structs to avoid passing them to their `GetChallenge` functions, since this is the way it's already implemented for other pseudonymsys structs.