### PR TITLE
Don't panic when server port is occupied

### DIFF
--- a/cli/server.go
+++ b/cli/server.go
@@ -32,6 +32,5 @@ func startEmmyServer(port int, certPath, keyPath string) error {
 		return err
 	}
 	srv.EnableTracing()
-	srv.Start(port)
-	return nil
+	return srv.Start(port)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -72,11 +72,11 @@ func NewProtocolServer(certFile, keyFile string) (*Server, error) {
 }
 
 // Start configures and starts the protocol server at the requested port.
-func (s *Server) Start(port int) {
+func (s *Server) Start(port int) error {
 	connStr := fmt.Sprintf(":%d", port)
 	listener, err := net.Listen("tcp", connStr)
 	if err != nil {
-		logger.Criticalf("Could not connect: %v", err)
+		return fmt.Errorf("Could not connect: %v", err)
 	}
 
 	// Register Prometheus metrics handler and serve metrics page on the desired endpoint.
@@ -91,6 +91,7 @@ func (s *Server) Start(port int) {
 	// From here on, gRPC server will accept connections
 	logger.Noticef("Emmy server listening for connections on port %d", port)
 	s.grpcServer.Serve(listener)
+	return nil
 }
 
 // Teardown stops the protocol server by gracefully stopping enclosed gRPC server.


### PR DESCRIPTION
This commit introduces a simple fix that reports an error instead of panicking when the server cannot be started due to an error emitted by `net.Listen(port)` call. This happens, for instance, when a port we want our server to listen on is occupied. 

The server CLI command now catches such errors and displays them to the user.

For instance, if we start the server via `emmy server start` in two terminal windows, the command in the second terminal window will display

```bash
$ emmy server start

2017/09/13 08:03:09 [server] 08:03:09.497 NewProtocolServer ▶ INFO 001 Instantiating new protocol server
2017/09/13 08:03:09 [server] 08:03:09.497 NewProtocolServer ▶ INFO 002 Registering services
2017/09/13 08:03:09 [server] 08:03:09.498 NewProtocolServer ▶ INFO 003 Successfully read certificate [test/testdata/server.pem] and key [test/testdata/server.key]
2017/09/13 08:03:09 [server] 08:03:09.498 NewProtocolServer ▶ NOTI 004 gRPC Services registered
2017/09/13 08:03:09 [server] 08:03:09.498 EnableTracing ▶ NOTI 005 Enabled gRPC tracing
2017/09/13 08:03:09 [server] 08:03:09.498 Start ▶ CRIT 006 Could not connect: listen tcp :7007: bind: address already in use
listen tcp :7007: bind: address already in use
```