### PR TITLE
Allow insecure TLS connections 

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -135,7 +135,7 @@ func run(ctx, subCmdCtx *cli.Context, f func(ctx *cli.Context, conn *grpc.Client
 
 	// Establish a connection to emmy server
 	client.SetLogLevel(ctx.String("loglevel"))
-	conn, err = client.GetConnection(ctx.String("server"), ctx.String("cacert"))
+	conn, err = client.GetConnection(ctx.String("server"), ctx.String("cacert"), ctx.Bool("insecure"))
 	if err != nil {
 		return cli.NewExitError(fmt.Sprintf("Cannot connect to gRPC server: %v", err), 2)
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -40,6 +40,13 @@ var caCertFlag = cli.StringFlag{
 	Usage: "`PATH` to certificate file of the CA that issued emmy server's certificate",
 }
 
+// insecureFlag indicates whether a client should use an insecure connection to connect to
+// the server, meaning that server's certificate and hostname will not be checked by the client.
+var insecureFlag = cli.BoolFlag{
+	Name:  "insecure",
+	Usage: "Whether to disable checking server's hostname and certificate chain",
+}
+
 // portFlag indicates the port where emmy server will listen.
 var portFlag = cli.IntFlag{
 	Name:  "port, p",
@@ -108,5 +115,6 @@ var clientFlags = []cli.Flag{
 	concurrencyFlag,
 	serverEndpointFlag,
 	caCertFlag,
+	insecureFlag,
 	logLevelFlag,
 }

--- a/client/tls.go
+++ b/client/tls.go
@@ -1,0 +1,28 @@
+package client
+
+import (
+	"crypto/tls"
+	"google.golang.org/grpc/credentials"
+)
+
+// getTLSClientCredentials generates appropriate TLS credentials that the client can use to
+// contact the server via TLS.
+// Client credentials are constructed either for secure (in production) or insecure (during
+// development) communication with the server
+func getTLSClientCredentials(caCertFile string,
+	insecure bool) (credentials.TransportCredentials, error) {
+	// Do not check server's hostname or CA certificate chain
+	// This should only be used for testing & development, when the server uses a self-signed cert
+	if insecure {
+		return credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+		}), nil
+	}
+
+	creds, err := credentials.NewClientTLSFromFile(caCertFile, "")
+	if err != nil {
+		return nil, err
+	}
+
+	return creds, err
+}

--- a/test/communication_test.go
+++ b/test/communication_test.go
@@ -37,7 +37,8 @@ func TestMain(m *testing.M) {
 	go server.Start(7008)
 
 	// Establish a connection to previously started server
-	testGrpcClientConn, err = client.GetConnection(testGrpcServerEndpoint, "testdata/server.pem")
+	testGrpcClientConn, err = client.GetConnection(testGrpcServerEndpoint,
+		"testdata/server.pem", false)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -1,0 +1,12 @@
+package test
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/xlab-si/emmy/client"
+	"testing"
+)
+
+func TestInsecureConn(t *testing.T) {
+	_, err := client.GetConnection(testGrpcServerEndpoint, "", true)
+	assert.Nil(t, err, "should finish without errors")
+}


### PR DESCRIPTION
Since #17, client and server use TLS to secure channel over which they communicate. However, for development and testing purposes we sometimes want to avoid errors stemming from the server's use of self-signed cert. 

In this PR we:
* add an additional parameter to client's `GetConnection()`, which specifies whether to avoid checking of server's CA cert chain and hostname. 
* Update the calls in the test code and client CLI code.
* Update README with explanation and examples that demonstrate the purpose and usage of the `--insecure` flag.
