### PR TITLE
Make transcript a struct in dlogproofs package

### DIFF
--- a/client/pseudonymsys.go
+++ b/client/pseudonymsys.go
@@ -248,16 +248,16 @@ func (c *PseudonymsysClient) TransferCredential(orgName string, userSecret *big.
 	x1, x2 := equalityProver.GetProofRandomData(userSecret, nym.A, credential.SmallAToGamma)
 
 	transcript1 := &pb.PseudonymsysTranscript{
-		A:      credential.T1[0].Bytes(),
-		B:      credential.T1[1].Bytes(),
-		Hash:   credential.T1[2].Bytes(),
-		ZAlpha: credential.T1[3].Bytes(),
+		A:      credential.T1.A.Bytes(),
+		B:      credential.T1.B.Bytes(),
+		Hash:   credential.T1.Hash.Bytes(),
+		ZAlpha: credential.T1.ZAlpha.Bytes(),
 	}
 	transcript2 := &pb.PseudonymsysTranscript{
-		A:      credential.T2[0].Bytes(),
-		B:      credential.T2[1].Bytes(),
-		Hash:   credential.T2[2].Bytes(),
-		ZAlpha: credential.T2[3].Bytes(),
+		A:      credential.T2.A.Bytes(),
+		B:      credential.T2.B.Bytes(),
+		Hash:   credential.T2.Hash.Bytes(),
+		ZAlpha: credential.T2.ZAlpha.Bytes(),
 	}
 	pbCredential := &pb.PseudonymsysCredential{
 		SmallAToGamma: credential.SmallAToGamma.Bytes(),

--- a/client/pseudonymsys_ec.go
+++ b/client/pseudonymsys_ec.go
@@ -272,20 +272,20 @@ func (c *PseudonymsysClientEC) TransferCredential(orgName string, userSecret *bi
 	x1, x2 := equalityProver.GetProofRandomData(userSecret, nym.A, credential.SmallAToGamma)
 
 	transcript1 := &pb.PseudonymsysTranscriptEC{
-		A: types.ToPbECGroupElement(types.NewECGroupElement(credential.T1[0],
-			credential.T1[1])),
-		B: types.ToPbECGroupElement(types.NewECGroupElement(credential.T1[2],
-			credential.T1[3])),
-		Hash:   credential.T1[4].Bytes(),
-		ZAlpha: credential.T1[5].Bytes(),
+		A: types.ToPbECGroupElement(types.NewECGroupElement(credential.T1.Alpha_1,
+			credential.T1.Alpha_2)),
+		B: types.ToPbECGroupElement(types.NewECGroupElement(credential.T1.Beta_1,
+			credential.T1.Beta_2)),
+		Hash:   credential.T1.Hash.Bytes(),
+		ZAlpha: credential.T1.ZAlpha.Bytes(),
 	}
 	transcript2 := &pb.PseudonymsysTranscriptEC{
-		A: types.ToPbECGroupElement(types.NewECGroupElement(credential.T2[0],
-			credential.T2[1])),
-		B: types.ToPbECGroupElement(types.NewECGroupElement(credential.T2[2],
-			credential.T2[3])),
-		Hash:   credential.T2[4].Bytes(),
-		ZAlpha: credential.T2[5].Bytes(),
+		A: types.ToPbECGroupElement(types.NewECGroupElement(credential.T2.Alpha_1,
+			credential.T2.Alpha_2)),
+		B: types.ToPbECGroupElement(types.NewECGroupElement(credential.T2.Beta_1,
+			credential.T2.Beta_2)),
+		Hash:   credential.T2.Hash.Bytes(),
+		ZAlpha: credential.T2.ZAlpha.Bytes(),
 	}
 	pbCredential := &pb.PseudonymsysCredentialEC{
 		SmallAToGamma: types.ToPbECGroupElement(credential.SmallAToGamma),

--- a/crypto/zkp/schemes/pseudonymsys/org_issue.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_issue.go
@@ -30,12 +30,12 @@ type Credential struct {
 	SmallBToGamma *big.Int
 	AToGamma      *big.Int
 	BToGamma      *big.Int
-	T1            []*big.Int
-	T2            []*big.Int
+	T1            *dlogproofs.Transcript
+	T2            *dlogproofs.Transcript
 }
 
 func NewCredential(aToGamma, bToGamma, AToGamma, BToGamma *big.Int,
-	t1, t2 []*big.Int) *Credential {
+	t1, t2 *dlogproofs.Transcript) *Credential {
 	credential := &Credential{
 		SmallAToGamma: aToGamma,
 		SmallBToGamma: bToGamma,

--- a/crypto/zkp/schemes/pseudonymsys/org_issue_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_issue_ec.go
@@ -30,12 +30,12 @@ type CredentialEC struct {
 	SmallBToGamma *types.ECGroupElement
 	AToGamma      *types.ECGroupElement
 	BToGamma      *types.ECGroupElement
-	T1            []*big.Int
-	T2            []*big.Int
+	T1            *dlogproofs.TranscriptEC
+	T2            *dlogproofs.TranscriptEC
 }
 
 func NewCredentialEC(aToGamma, bToGamma, AToGamma, BToGamma *types.ECGroupElement,
-	t1, t2 []*big.Int) *CredentialEC {
+	t1, t2 *dlogproofs.TranscriptEC) *CredentialEC {
 	credential := &CredentialEC{
 		SmallAToGamma: aToGamma,
 		SmallBToGamma: bToGamma,

--- a/server/pseudonymsys.go
+++ b/server/pseudonymsys.go
@@ -19,6 +19,7 @@ package server
 
 import (
 	"github.com/xlab-si/emmy/config"
+	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"math/big"
@@ -178,17 +179,19 @@ func (s *Server) PseudonymsysTransferCredential(req *pb.Message, stream pb.Proto
 	nymA := new(big.Int).SetBytes(data.NymA)
 	nymB := new(big.Int).SetBytes(data.NymB)
 
-	t1 := make([]*big.Int, 4)
-	t1[0] = new(big.Int).SetBytes(data.Credential.T1.A)
-	t1[1] = new(big.Int).SetBytes(data.Credential.T1.B)
-	t1[2] = new(big.Int).SetBytes(data.Credential.T1.Hash)
-	t1[3] = new(big.Int).SetBytes(data.Credential.T1.ZAlpha)
+	t1 := dlogproofs.NewTranscript(
+		new(big.Int).SetBytes(data.Credential.T1.A),
+		new(big.Int).SetBytes(data.Credential.T1.B),
+		new(big.Int).SetBytes(data.Credential.T1.Hash),
+		new(big.Int).SetBytes(data.Credential.T1.ZAlpha),
+	)
 
-	t2 := make([]*big.Int, 4)
-	t2[0] = new(big.Int).SetBytes(data.Credential.T2.A)
-	t2[1] = new(big.Int).SetBytes(data.Credential.T2.B)
-	t2[2] = new(big.Int).SetBytes(data.Credential.T2.Hash)
-	t2[3] = new(big.Int).SetBytes(data.Credential.T2.ZAlpha)
+	t2 := dlogproofs.NewTranscript(
+		new(big.Int).SetBytes(data.Credential.T2.A),
+		new(big.Int).SetBytes(data.Credential.T2.B),
+		new(big.Int).SetBytes(data.Credential.T2.Hash),
+		new(big.Int).SetBytes(data.Credential.T2.ZAlpha),
+	)
 
 	credential := pseudonymsys.NewCredential(
 		new(big.Int).SetBytes(data.Credential.SmallAToGamma),

--- a/server/pseudonymsys_ec.go
+++ b/server/pseudonymsys_ec.go
@@ -20,6 +20,7 @@ package server
 import (
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/dlog"
+	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
@@ -181,21 +182,21 @@ func (s *Server) PseudonymsysTransferCredentialEC(curveType dlog.Curve, req *pb.
 	nymA := types.ToECGroupElement(data.NymA)
 	nymB := types.ToECGroupElement(data.NymB)
 
-	t1 := make([]*big.Int, 6)
-	t1[0] = new(big.Int).SetBytes(data.Credential.T1.A.X)
-	t1[1] = new(big.Int).SetBytes(data.Credential.T1.A.Y)
-	t1[2] = new(big.Int).SetBytes(data.Credential.T1.B.X)
-	t1[3] = new(big.Int).SetBytes(data.Credential.T1.B.Y)
-	t1[4] = new(big.Int).SetBytes(data.Credential.T1.Hash)
-	t1[5] = new(big.Int).SetBytes(data.Credential.T1.ZAlpha)
+	t1 := dlogproofs.NewTranscriptEC(
+		new(big.Int).SetBytes(data.Credential.T1.A.X),
+		new(big.Int).SetBytes(data.Credential.T1.A.Y),
+		new(big.Int).SetBytes(data.Credential.T1.B.X),
+		new(big.Int).SetBytes(data.Credential.T1.B.Y),
+		new(big.Int).SetBytes(data.Credential.T1.Hash),
+		new(big.Int).SetBytes(data.Credential.T1.ZAlpha))
 
-	t2 := make([]*big.Int, 6)
-	t2[0] = new(big.Int).SetBytes(data.Credential.T2.A.X)
-	t2[1] = new(big.Int).SetBytes(data.Credential.T2.A.Y)
-	t2[2] = new(big.Int).SetBytes(data.Credential.T2.B.X)
-	t2[3] = new(big.Int).SetBytes(data.Credential.T2.B.Y)
-	t2[4] = new(big.Int).SetBytes(data.Credential.T2.Hash)
-	t2[5] = new(big.Int).SetBytes(data.Credential.T2.ZAlpha)
+	t2 := dlogproofs.NewTranscriptEC(
+		new(big.Int).SetBytes(data.Credential.T2.A.X),
+		new(big.Int).SetBytes(data.Credential.T2.A.Y),
+		new(big.Int).SetBytes(data.Credential.T2.B.X),
+		new(big.Int).SetBytes(data.Credential.T2.B.Y),
+		new(big.Int).SetBytes(data.Credential.T2.Hash),
+		new(big.Int).SetBytes(data.Credential.T2.ZAlpha))
 
 	credential := pseudonymsys.NewCredentialEC(
 		types.ToECGroupElement(data.Credential.SmallAToGamma),


### PR DESCRIPTION
This commit introduces Transcript struct in the dlogproofs package. It greatly improves readability. In addition, it will allow us to easily achieve compatibility with types supported by go tools for creating language bindings.

Resolves #33.