### PR TITLE
Swap service description and provider in LoadServiceInfo

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -134,7 +134,7 @@ func LoadServiceInfo() *types.ServiceInfo {
 	serviceName := viper.GetString("service_info.name")
 	serviceProvider := viper.GetString("service_info.provider")
 	serviceDescription := viper.GetString("service_info.description")
-	return types.NewServiceInfo(serviceName, serviceProvider, serviceDescription)
+	return types.NewServiceInfo(serviceName, serviceDescription, serviceProvider)
 }
 
 func LoadSessionKeyMinByteLen() int {


### PR DESCRIPTION
This commit swaps `serviceProvider` and `serviceDescription` arguments that were accidentally passed in an incorrect order to `NewServiceInfo` function call within `config.go`'s `LoadServiceInfo`.