### PR TITLE
Format source code with goimports

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -19,6 +19,11 @@ package cli
 
 import (
 	"fmt"
+	"math/big"
+	"strings"
+	"sync"
+	"time"
+
 	"github.com/urfave/cli"
 	"github.com/xlab-si/emmy/client"
 	"github.com/xlab-si/emmy/config"
@@ -27,10 +32,6 @@ import (
 	"github.com/xlab-si/emmy/log"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"google.golang.org/grpc"
-	"math/big"
-	"strings"
-	"sync"
-	"time"
 )
 
 var ClientCmd = cli.Command{

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -21,9 +21,10 @@ package cli
 // or subcommands of the emmy CLI.
 
 import (
+	"path/filepath"
+
 	"github.com/urfave/cli"
 	"github.com/xlab-si/emmy/config"
-	"path/filepath"
 )
 
 // logLevelFlag indicates the log level applied to client/server loggers.

--- a/client/client.go
+++ b/client/client.go
@@ -19,14 +19,15 @@ package client
 
 import (
 	"fmt"
+	"io"
+	"math/rand"
+	"time"
+
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/log"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"io"
-	"math/rand"
-	"time"
 )
 
 var logger log.Logger

--- a/client/cs_paillier.go
+++ b/client/cs_paillier.go
@@ -18,10 +18,11 @@
 package client
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/encryption"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type CSPaillierClient struct {

--- a/client/info.go
+++ b/client/info.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"fmt"
+
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"golang.org/x/net/context"

--- a/client/pedersen.go
+++ b/client/pedersen.go
@@ -18,11 +18,12 @@
 package client
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/groups"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type PedersenClient struct {

--- a/client/pedersen_common.go
+++ b/client/pedersen_common.go
@@ -18,8 +18,9 @@
 package client
 
 import (
-	pb "github.com/xlab-si/emmy/protobuf"
 	"math/big"
+
+	pb "github.com/xlab-si/emmy/protobuf"
 )
 
 type pedersenCommonClient struct {

--- a/client/pedersen_ec.go
+++ b/client/pedersen_ec.go
@@ -18,12 +18,13 @@
 package client
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/groups"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type PedersenECClient struct {

--- a/client/pseudonymsys.go
+++ b/client/pseudonymsys.go
@@ -20,6 +20,8 @@ package client
 import (
 	"errors"
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
@@ -28,7 +30,6 @@ import (
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type PseudonymsysClient struct {

--- a/client/pseudonymsys_ca.go
+++ b/client/pseudonymsys_ca.go
@@ -18,13 +18,14 @@
 package client
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type PseudonymsysCAClient struct {

--- a/client/pseudonymsys_ca_ec.go
+++ b/client/pseudonymsys_ca_ec.go
@@ -18,13 +18,14 @@
 package client
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type PseudonymsysCAClientEC struct {

--- a/client/pseudonymsys_ec.go
+++ b/client/pseudonymsys_ec.go
@@ -20,6 +20,8 @@ package client
 import (
 	"errors"
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
@@ -27,7 +29,6 @@ import (
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type PseudonymsysClientEC struct {

--- a/client/qnr.go
+++ b/client/qnr.go
@@ -20,12 +20,13 @@ package client
 import (
 	"errors"
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/qrproofs"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type QNRClient struct {

--- a/client/qr.go
+++ b/client/qr.go
@@ -18,11 +18,12 @@
 package client
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/qrproofs"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type QRClient struct {

--- a/client/schnorr.go
+++ b/client/schnorr.go
@@ -19,12 +19,13 @@ package client
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type SchnorrClient struct {

--- a/client/schnorr_ec.go
+++ b/client/schnorr_ec.go
@@ -19,12 +19,13 @@ package client
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
-	"math/big"
 )
 
 type SchnorrECClient struct {

--- a/client/tls.go
+++ b/client/tls.go
@@ -19,6 +19,7 @@ package client
 
 import (
 	"crypto/tls"
+
 	"google.golang.org/grpc/credentials"
 )
 

--- a/config/config.go
+++ b/config/config.go
@@ -19,10 +19,11 @@ package config
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/spf13/viper"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // init loads the default config file

--- a/crypto/commitments/damgard-fujisaki.go
+++ b/crypto/commitments/damgard-fujisaki.go
@@ -19,9 +19,10 @@ package commitments
 
 import (
 	"errors"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
-	"math/big"
 )
 
 // DamgardFujisaki demonstrates how a value can be committed and later opened (decommitted).

--- a/crypto/commitments/pedersen.go
+++ b/crypto/commitments/pedersen.go
@@ -19,9 +19,10 @@ package commitments
 
 import (
 	"errors"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
-	"math/big"
 )
 
 // TODO: might be better to have only one method (like GetCommitment) instead of

--- a/crypto/commitments/pedersen_ec.go
+++ b/crypto/commitments/pedersen_ec.go
@@ -19,10 +19,11 @@ package commitments
 
 import (
 	"errors"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // Committer first needs to know H (it gets it from the receiver).

--- a/crypto/commitments/rsa_based.go
+++ b/crypto/commitments/rsa_based.go
@@ -21,8 +21,9 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/xlab-si/emmy/crypto/groups"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/groups"
 )
 
 // GenerateRSABasedQOneWay generates RSA group rsa_group,

--- a/crypto/encryption/cs_paillier.go
+++ b/crypto/encryption/cs_paillier.go
@@ -19,13 +19,14 @@ package encryption
 
 import (
 	"errors"
+	"log"
+	"math/big"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/storage"
-	"log"
-	"math/big"
 )
 
 // todo: does hash really need to be into [0, 2^l]?

--- a/crypto/encryption/paillier.go
+++ b/crypto/encryption/paillier.go
@@ -20,8 +20,9 @@ package encryption
 import (
 	"crypto/rand"
 	"errors"
-	"github.com/xlab-si/emmy/crypto/common"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 // https://pirk.incubator.apache.org/papers/1999_asiacrypt_paillier_paper.pdf

--- a/crypto/groups/ec.go
+++ b/crypto/groups/ec.go
@@ -19,9 +19,10 @@ package groups
 
 import (
 	"crypto/elliptic"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 type ECurve int

--- a/crypto/groups/qr_rsa.go
+++ b/crypto/groups/qr_rsa.go
@@ -19,8 +19,9 @@ package groups
 
 import (
 	"errors"
-	"github.com/xlab-si/emmy/crypto/common"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 // QRRSA presents QR_N - group of quadratic residues modulo N where N is a product

--- a/crypto/groups/qr_special_rsa.go
+++ b/crypto/groups/qr_special_rsa.go
@@ -21,8 +21,9 @@ package groups
 
 import (
 	"errors"
-	"github.com/xlab-si/emmy/crypto/common"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 // QRSpecialRSA presents QR_N - group of quadratic residues modulo N where N is a product

--- a/crypto/groups/schnorr.go
+++ b/crypto/groups/schnorr.go
@@ -21,8 +21,9 @@ import (
 	"crypto/dsa"
 	"crypto/rand"
 	"fmt"
-	"github.com/xlab-si/emmy/crypto/common"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 // SchnorrGroup is a cyclic group in modular arithmetic. It holds P = Q * R + 1 for some R.

--- a/crypto/groups/zn.go
+++ b/crypto/groups/zn.go
@@ -18,8 +18,9 @@
 package groups
 
 import (
-	"github.com/xlab-si/emmy/crypto/common"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 // Zn presents Z_n* - group of all integers smaller than n and coprime with n.

--- a/crypto/secretsharing/dealer.go
+++ b/crypto/secretsharing/dealer.go
@@ -20,8 +20,9 @@ package secretsharing
 import (
 	"crypto/rand"
 	"errors"
-	"github.com/xlab-si/emmy/crypto/common"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 // Shamir's secret sharing scheme

--- a/crypto/signatures/cl.go
+++ b/crypto/signatures/cl.go
@@ -20,9 +20,10 @@ package signatures
 import (
 	"crypto/rand"
 	"errors"
-	"github.com/xlab-si/emmy/crypto/common"
 	"log"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 type CL struct {

--- a/crypto/zkp/primitives/commitments/rsa_based.go
+++ b/crypto/zkp/primitives/commitments/rsa_based.go
@@ -18,12 +18,13 @@
 package commitmentzkp
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/preimage"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // ProveBitCommitment demonstrates how committer can prove that a commitment contains

--- a/crypto/zkp/primitives/dlogproofs/dlog_equality.go
+++ b/crypto/zkp/primitives/dlogproofs/dlog_equality.go
@@ -18,9 +18,10 @@
 package dlogproofs
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
-	"math/big"
 )
 
 // ProveDLogEquality demonstrates how prover can prove the knowledge of log_g1(t1), log_g2(t2) and

--- a/crypto/zkp/primitives/dlogproofs/dlog_equality_blinded_transcript.go
+++ b/crypto/zkp/primitives/dlogproofs/dlog_equality_blinded_transcript.go
@@ -18,9 +18,10 @@
 package dlogproofs
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
-	"math/big"
 )
 
 type Transcript struct {

--- a/crypto/zkp/primitives/dlogproofs/dlog_equality_blinded_transcript_ec.go
+++ b/crypto/zkp/primitives/dlogproofs/dlog_equality_blinded_transcript_ec.go
@@ -18,10 +18,11 @@
 package dlogproofs
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // Verifies that the blinded transcript is valid. That means the knowledge of log_g1(t1), log_G2(T2)

--- a/crypto/zkp/primitives/dlogproofs/dlog_equality_ec.go
+++ b/crypto/zkp/primitives/dlogproofs/dlog_equality_ec.go
@@ -18,10 +18,11 @@
 package dlogproofs
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // ProveECDLogEquality demonstrates how prover can prove the knowledge of log_g1(t1), log_g2(t2) and

--- a/crypto/zkp/primitives/dlogproofs/partial_dlog_knowledge.go
+++ b/crypto/zkp/primitives/dlogproofs/partial_dlog_knowledge.go
@@ -18,10 +18,11 @@
 package dlogproofs
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // ProvePartialDLogKnowledge demonstrates how prover can prove that he knows dlog_a2(b2) and

--- a/crypto/zkp/primitives/dlogproofs/partial_dlog_knowledge_ec.go
+++ b/crypto/zkp/primitives/dlogproofs/partial_dlog_knowledge_ec.go
@@ -18,10 +18,11 @@
 package dlogproofs
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // ProvePartialECDLogKnowledge demonstrates how prover can prove that he knows dlog_a2(b2) and

--- a/crypto/zkp/primitives/dlogproofs/schnorr.go
+++ b/crypto/zkp/primitives/dlogproofs/schnorr.go
@@ -18,11 +18,12 @@
 package dlogproofs
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // ProveDLogKnowledge demonstrates how prover can prove the knowledge of log_g1(t1) - that

--- a/crypto/zkp/primitives/dlogproofs/schnorr_ec.go
+++ b/crypto/zkp/primitives/dlogproofs/schnorr_ec.go
@@ -18,11 +18,12 @@
 package dlogproofs
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // ProveECDLogKnowledge demonstrates how prover can prove the knowledge of log_g1(t1) - that

--- a/crypto/zkp/primitives/preimage/homomorphism_partial_preimage_knowledge.go
+++ b/crypto/zkp/primitives/preimage/homomorphism_partial_preimage_knowledge.go
@@ -18,10 +18,11 @@
 package preimage
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // ProvePartialPreimageKnowledge demonstrates how prover can prove that he knows f^(-1)(u1) and

--- a/crypto/zkp/primitives/preimage/homomorphism_preimage_knowledge.go
+++ b/crypto/zkp/primitives/preimage/homomorphism_preimage_knowledge.go
@@ -18,9 +18,10 @@
 package preimage
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
-	"math/big"
 )
 
 // ProvePreimageKnowledge demonstrates how given homomorphism f:H->G and element u from G

--- a/crypto/zkp/primitives/qrproofs/qnr.go
+++ b/crypto/zkp/primitives/qrproofs/qnr.go
@@ -21,10 +21,11 @@ package qrproofs
 
 import (
 	"errors"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 // ProveQNR demonstrates how the prover can prove that y is not quadratic residue (there does

--- a/crypto/zkp/primitives/qrproofs/qr.go
+++ b/crypto/zkp/primitives/qrproofs/qr.go
@@ -21,9 +21,10 @@ package qrproofs
 
 import (
 	"errors"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
-	"math/big"
 )
 
 // ProveQR demonstrates how the prover can prove that y1^2 is QR.

--- a/crypto/zkp/primitives/representationproofs/representation.go
+++ b/crypto/zkp/primitives/representationproofs/representation.go
@@ -19,9 +19,10 @@ package representationproofs
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
-	"math/big"
 )
 
 // ProveKnowledgeOfRepresentation demonstrates how the prover proves that it knows (x_1,...,x_k)

--- a/crypto/zkp/schemes/pseudonymsys/ca.go
+++ b/crypto/zkp/schemes/pseudonymsys/ca.go
@@ -21,11 +21,12 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 type CA struct {

--- a/crypto/zkp/schemes/pseudonymsys/ca_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/ca_ec.go
@@ -21,11 +21,12 @@ import (
 	"crypto/ecdsa"
 	"crypto/rand"
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 type CAEC struct {

--- a/crypto/zkp/schemes/pseudonymsys/org_issue.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_issue.go
@@ -19,10 +19,11 @@ package pseudonymsys
 
 import (
 	"errors"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 type Credential struct {

--- a/crypto/zkp/schemes/pseudonymsys/org_issue_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_issue_ec.go
@@ -19,10 +19,11 @@ package pseudonymsys
 
 import (
 	"errors"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 type CredentialEC struct {

--- a/crypto/zkp/schemes/pseudonymsys/org_nym_gen.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_nym_gen.go
@@ -20,10 +20,11 @@ package pseudonymsys
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
-	"math/big"
 )
 
 type Pseudonym struct {

--- a/crypto/zkp/schemes/pseudonymsys/org_nym_gen_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_nym_gen_ec.go
@@ -20,11 +20,12 @@ package pseudonymsys
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 type PseudonymEC struct {

--- a/crypto/zkp/schemes/pseudonymsys/org_transfer.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_transfer.go
@@ -18,9 +18,10 @@
 package pseudonymsys
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
-	"math/big"
 )
 
 type OrgCredentialVerifier struct {

--- a/crypto/zkp/schemes/pseudonymsys/org_transfer_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_transfer_ec.go
@@ -18,10 +18,11 @@
 package pseudonymsys
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 type OrgCredentialVerifierEC struct {

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,5 +1,9 @@
 # Emmy - development
 
+## Source code formatting
+All contributions to *emmy* library should conform to source formatting enforced by [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports).
+Please install *goimports* and configure your source code editor to automatically run it on every file save.
+
 ## To compile .proto files
 
 Go into the root project folder and execute:

--- a/emmy.go
+++ b/emmy.go
@@ -18,9 +18,10 @@
 package main
 
 import (
+	"os"
+
 	"github.com/urfave/cli"
 	emmy "github.com/xlab-si/emmy/cli"
-	"os"
 )
 
 // main runs the emmy CLI app.

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/op/go-logging"
 	"io"
+
+	"github.com/op/go-logging"
 )
 
 // Logger is a convenience interface that makes use of all functionality from go-logging's

--- a/log/logger_file.go
+++ b/log/logger_file.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/op/go-logging"
 	"os"
+
+	"github.com/op/go-logging"
 )
 
 // FileLogger outputs logs to a given file.

--- a/log/logger_null.go
+++ b/log/logger_null.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/op/go-logging"
 	"io/ioutil"
+
+	"github.com/op/go-logging"
 )
 
 // NullLogger suppresses logging output

--- a/log/logger_stdout.go
+++ b/log/logger_stdout.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/op/go-logging"
 	"os"
+
+	"github.com/op/go-logging"
 )
 
 // StdoutLogger outputs logs to standard output.

--- a/log/logger_stdout_file.go
+++ b/log/logger_stdout_file.go
@@ -1,8 +1,9 @@
 package log
 
 import (
-	"github.com/op/go-logging"
 	"os"
+
+	"github.com/op/go-logging"
 )
 
 // StdoutFileLogger outputs logs both to standard output as well as to a given file.

--- a/server/cs_paillier.go
+++ b/server/cs_paillier.go
@@ -18,9 +18,10 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/encryption"
 	pb "github.com/xlab-si/emmy/protobuf"
-	"math/big"
 )
 
 func (s *Server) CSPaillier(req *pb.Message, secKeyPath string, stream pb.Protocol_RunServer) error {

--- a/server/pedersen.go
+++ b/server/pedersen.go
@@ -18,10 +18,11 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/groups"
 	pb "github.com/xlab-si/emmy/protobuf"
-	"math/big"
 )
 
 func (s *Server) Pedersen(group *groups.SchnorrGroup, stream pb.Protocol_RunServer) error {

--- a/server/pedersen_ec.go
+++ b/server/pedersen_ec.go
@@ -18,11 +18,12 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/groups"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 func (s *Server) PedersenEC(curveType groups.ECurve, stream pb.Protocol_RunServer) error {

--- a/server/pseudonymsys.go
+++ b/server/pseudonymsys.go
@@ -18,11 +18,12 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
-	"math/big"
 )
 
 func (s *Server) PseudonymsysGenerateNym(req *pb.Message, stream pb.Protocol_RunServer) error {

--- a/server/pseudonymsys_ca.go
+++ b/server/pseudonymsys_ca.go
@@ -18,10 +18,11 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
-	"math/big"
 )
 
 func (s *Server) PseudonymsysCA(req *pb.Message, stream pb.Protocol_RunServer) error {

--- a/server/pseudonymsys_ca_ec.go
+++ b/server/pseudonymsys_ca_ec.go
@@ -18,12 +18,13 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 func (s *Server) PseudonymsysCAEC(curveType groups.ECurve, req *pb.Message,

--- a/server/pseudonymsys_ec.go
+++ b/server/pseudonymsys_ec.go
@@ -18,13 +18,14 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 func (s *Server) PseudonymsysGenerateNymEC(curveType groups.ECurve, req *pb.Message,

--- a/server/qnr.go
+++ b/server/qnr.go
@@ -19,11 +19,12 @@ package server
 
 import (
 	"fmt"
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/qrproofs"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 func (s *Server) QNR(req *pb.Message, qr *groups.QRRSA,

--- a/server/qr.go
+++ b/server/qr.go
@@ -18,10 +18,11 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/qrproofs"
 	pb "github.com/xlab-si/emmy/protobuf"
-	"math/big"
 )
 
 func (s *Server) QR(req *pb.Message, group *groups.SchnorrGroup,

--- a/server/schnorr.go
+++ b/server/schnorr.go
@@ -18,11 +18,12 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 func (s *Server) Schnorr(req *pb.Message, group *groups.SchnorrGroup,

--- a/server/schnorr_ec.go
+++ b/server/schnorr_ec.go
@@ -18,11 +18,12 @@
 package server
 
 import (
+	"math/big"
+
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
 )
 
 func (s *Server) SchnorrEC(req *pb.Message, protocolType types.ProtocolType,

--- a/server/server.go
+++ b/server/server.go
@@ -19,6 +19,12 @@ package server
 
 import (
 	"fmt"
+	"io"
+	"math"
+	"net"
+	"net/http"
+	"path/filepath"
+
 	"github.com/grpc-ecosystem/go-grpc-prometheus"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/xlab-si/emmy/config"
@@ -28,11 +34,6 @@ import (
 	"github.com/xlab-si/emmy/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
-	"io"
-	"math"
-	"net"
-	"net/http"
-	"path/filepath"
 )
 
 var _ pb.ProtocolServer = (*Server)(nil)

--- a/test/commitments_test.go
+++ b/test/commitments_test.go
@@ -19,11 +19,12 @@ package test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/commitments"
-	"testing"
 )
 
 func TestRSABasedCommitment(t *testing.T) {

--- a/test/common_test.go
+++ b/test/common_test.go
@@ -18,11 +18,12 @@
 package test
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/xlab-si/emmy/crypto/common"
 	"log"
 	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 func TestLCM(t *testing.T) {

--- a/test/communication_test.go
+++ b/test/communication_test.go
@@ -19,6 +19,10 @@ package test
 
 import (
 	"fmt"
+	"math/big"
+	"os"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/client"
 	"github.com/xlab-si/emmy/config"
@@ -28,9 +32,6 @@ import (
 	pb "github.com/xlab-si/emmy/protobuf"
 	"github.com/xlab-si/emmy/server"
 	"google.golang.org/grpc"
-	"math/big"
-	"os"
-	"testing"
 )
 
 var testGrpcServerEndpoint = "localhost:7008"

--- a/test/dlog_test.go
+++ b/test/dlog_test.go
@@ -19,13 +19,14 @@ package test
 
 import (
 	"fmt"
+	"math/big"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
-	"math/big"
-	"testing"
 )
 
 func TestDLogKnowledge(t *testing.T) {

--- a/test/encryption_test.go
+++ b/test/encryption_test.go
@@ -18,13 +18,14 @@
 package test
 
 import (
+	"math/big"
+	"path/filepath"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/encryption"
-	"math/big"
-	"path/filepath"
-	"testing"
 )
 
 func TestPaillier(t *testing.T) {

--- a/test/groups_test.go
+++ b/test/groups_test.go
@@ -19,10 +19,11 @@ package test
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/xlab-si/emmy/crypto/groups"
 	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xlab-si/emmy/crypto/groups"
 )
 
 func TestGeneratorOfCompositeQR(t *testing.T) {

--- a/test/info_test.go
+++ b/test/info_test.go
@@ -18,9 +18,10 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/client"
-	"testing"
 )
 
 func TestGetServiceInfo(t *testing.T) {

--- a/test/logging_test.go
+++ b/test/logging_test.go
@@ -1,9 +1,10 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/log"
-	"testing"
 )
 
 func TestInvalidLogLevel(t *testing.T) {

--- a/test/preimage_test.go
+++ b/test/preimage_test.go
@@ -18,10 +18,11 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/crypto/commitments"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/preimage"
-	"testing"
 )
 
 func TestHomomorphismPreimage(t *testing.T) {

--- a/test/pseudonymsys_ec_test.go
+++ b/test/pseudonymsys_ec_test.go
@@ -18,14 +18,15 @@
 package test
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/client"
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	"github.com/xlab-si/emmy/types"
-	"math/big"
-	"testing"
 )
 
 func TestPseudonymsysEC(t *testing.T) {

--- a/test/pseudonymsys_test.go
+++ b/test/pseudonymsys_test.go
@@ -18,14 +18,15 @@
 package test
 
 import (
+	"math/big"
+	"testing"
+	"time"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/client"
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	"github.com/xlab-si/emmy/server"
-	"math/big"
-	"testing"
-	"time"
 )
 
 // TestPseudonymsys requires a running server (it is started in communication_test.go).

--- a/test/qr_test.go
+++ b/test/qr_test.go
@@ -18,13 +18,14 @@
 package test
 
 import (
+	"math/big"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/client"
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/log"
-	"math/big"
-	"testing"
 )
 
 func TestQRProof(t *testing.T) {

--- a/test/representation_test.go
+++ b/test/representation_test.go
@@ -18,9 +18,10 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/representationproofs"
-	"testing"
 )
 
 func TestRepresentationProof(t *testing.T) {

--- a/test/signatures_test.go
+++ b/test/signatures_test.go
@@ -18,11 +18,12 @@
 package test
 
 import (
-	"github.com/xlab-si/emmy/crypto/common"
-	"github.com/xlab-si/emmy/crypto/signatures"
 	"log"
 	"math/big"
 	"testing"
+
+	"github.com/xlab-si/emmy/crypto/common"
+	"github.com/xlab-si/emmy/crypto/signatures"
 )
 
 func TestCL(t *testing.T) {

--- a/test/tls_test.go
+++ b/test/tls_test.go
@@ -18,9 +18,10 @@
 package test
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/client"
-	"testing"
 )
 
 func TestInsecureConn(t *testing.T) {

--- a/types/types.go
+++ b/types/types.go
@@ -18,8 +18,9 @@
 package types
 
 import (
-	pb "github.com/xlab-si/emmy/protobuf"
 	"math/big"
+
+	pb "github.com/xlab-si/emmy/protobuf"
 )
 
 type ProtocolType uint8


### PR DESCRIPTION
So far we have been using [gofmt](https://golang.org/cmd/gofmt/), which was totally fine. However, there is a tool called *goimports* that formats the source with *gofmt* and organizes imports as well, which is nice and apparently the way to go these days (according to [these](https://github.com/golang/go/wiki/CodeReviewComments) and [these guidelines](https://peter.bourgon.org/go-best-practices-2016/#formatting-and-style) and many more) :slightly_smiling_face: 

This PR formats emmy's Go source files with [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports). In addition, it updates the docs in `docs/develop.md` with a notice that (from now on) all the source code contributed to emmy should be formatted with  *goimports*.