### PR TITLE
Make error statements and their formatting consistent

### DIFF
--- a/cli/client.go
+++ b/cli/client.go
@@ -58,7 +58,7 @@ var clientSubcommands = []cli.Command{
 				secret := big.NewInt(ctx.Int64("secret"))
 				client, err := client.NewPedersenClient(conn, pbVariant, group, secret)
 				if err != nil {
-					return fmt.Errorf("Error creating client: %v", err)
+					return fmt.Errorf("error creating client: %v", err)
 				}
 				return client.Run()
 			})
@@ -75,7 +75,7 @@ var clientSubcommands = []cli.Command{
 				curve := groups.P256
 				client, err := client.NewPedersenECClient(conn, secret, curve)
 				if err != nil {
-					return fmt.Errorf("Error creating client: %v", err)
+					return fmt.Errorf("error creating client: %v", err)
 				}
 				return client.Run()
 			})
@@ -96,7 +96,7 @@ var clientSubcommands = []cli.Command{
 				secret := big.NewInt(ctx.Int64("secret"))
 				client, err := client.NewSchnorrClient(conn, pbVariant, group, secret)
 				if err != nil {
-					return fmt.Errorf("Error creating client: %v", err)
+					return fmt.Errorf("error creating client: %v", err)
 				}
 				return client.Run()
 			})
@@ -117,7 +117,7 @@ var clientSubcommands = []cli.Command{
 				secret := big.NewInt(ctx.Int64("secret"))
 				client, err := client.NewSchnorrClient(conn, pbVariant, group, secret)
 				if err != nil {
-					return fmt.Errorf("Error creating client: %v", err)
+					return fmt.Errorf("error creating client: %v", err)
 				}
 				return client.Run()
 			})
@@ -135,7 +135,7 @@ var clientSubcommands = []cli.Command{
 				pubKey := ctx.String("pubkey")
 				client, err := client.NewCSPaillierClient(conn, pubKey, secret, label)
 				if err != nil {
-					return fmt.Errorf("Error creating client: %v", err)
+					return fmt.Errorf("error creating client: %v", err)
 				}
 				return client.Run()
 			})

--- a/client/client.go
+++ b/client/client.go
@@ -69,7 +69,7 @@ func GetConnection(serverEndpoint, caCert string, insecure bool) (*grpc.ClientCo
 	// Create client TLS credentials
 	creds, err := getTLSClientCredentials(caCert, insecure)
 	if err != nil {
-		return nil, fmt.Errorf("Error creating TLS client credentials: %v", err)
+		return nil, fmt.Errorf("error creating TLS client credentials: %v", err)
 	}
 
 	dialOptions := []grpc.DialOption{
@@ -79,7 +79,7 @@ func GetConnection(serverEndpoint, caCert string, insecure bool) (*grpc.ClientCo
 	}
 	conn, err := grpc.Dial(serverEndpoint, dialOptions...)
 	if err != nil {
-		return nil, fmt.Errorf("Could not connect to server %v (%v)", serverEndpoint, err)
+		return nil, fmt.Errorf("could not connect to server %v (%v)", serverEndpoint, err)
 	}
 	logger.Notice("Established connection to gRPC server")
 	return conn, nil
@@ -108,9 +108,9 @@ func newGenericClient(conn *grpc.ClientConn) (*genericClient, error) {
 
 func (c *genericClient) send(msg *pb.Message) error {
 	if err := c.stream.Send(msg); err != nil {
-		return fmt.Errorf("[Client %v] Error sending message: %v", c.id, err)
+		return fmt.Errorf("[client %v] Error sending message: %v", c.id, err)
 	}
-	logger.Infof("[Client %v] Successfully sent request of type %T", c.id, msg.Content)
+	logger.Infof("[client %v] Successfully sent request of type %T", c.id, msg.Content)
 	logger.Debugf("%+v", msg)
 
 	return nil
@@ -119,14 +119,14 @@ func (c *genericClient) send(msg *pb.Message) error {
 func (c *genericClient) receive() (*pb.Message, error) {
 	resp, err := c.stream.Recv()
 	if err == io.EOF {
-		return nil, fmt.Errorf("[Client %v] EOF error", c.id)
+		return nil, fmt.Errorf("[client %v] EOF error", c.id)
 	} else if err != nil {
-		return nil, fmt.Errorf("[Client %v] An error ocurred: %v", c.id, err)
+		return nil, fmt.Errorf("[client %v] An error ocurred: %v", c.id, err)
 	}
 	if resp.ProtocolError != "" {
 		return nil, fmt.Errorf(resp.ProtocolError)
 	}
-	logger.Infof("[Client %v] Received response of type %T from the stream", c.id, resp.Content)
+	logger.Infof("[client %v] Received response of type %T from the stream", c.id, resp.Content)
 	logger.Debugf("%+v", resp)
 
 	return resp, nil
@@ -146,7 +146,7 @@ func (c *genericClient) getResponseTo(msg *pb.Message) (*pb.Message, error) {
 func (c *genericClient) openStream() error {
 	stream, err := c.protocolClient.Run(context.Background())
 	if err != nil {
-		return fmt.Errorf("[Client %v] Error opening stream: %v", c.id, err)
+		return fmt.Errorf("[client %v] Error opening stream: %v", c.id, err)
 	}
 
 	c.stream = stream

--- a/client/info.go
+++ b/client/info.go
@@ -47,7 +47,7 @@ func GetServiceInfo(conn *grpc.ClientConn) (*ServiceInfo, error) {
 
 	info, err := client.GetServiceInfo(context.Background(), &pb.EmptyMsg{})
 	if err != nil {
-		return nil, fmt.Errorf("Unable to retrieve service info: %v", err)
+		return nil, fmt.Errorf("unable to retrieve service info: %v", err)
 	}
 
 	serviceInfo := NewServiceInfo(info.GetName(), info.GetDescription(), info.GetProvider())

--- a/client/pseudonymsys.go
+++ b/client/pseudonymsys.go
@@ -18,7 +18,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -127,7 +126,7 @@ func (c *PseudonymsysClient) GenerateNym(userSecret *big.Int,
 		// todo: store in some DB: (orgName, nymA, nymB)
 		return pseudonymsys.NewPseudonym(nymA, nymB), nil
 	} else {
-		err := errors.New("The proof for nym registration failed.")
+		err := fmt.Errorf("proof for nym registration failed")
 		return nil, err
 	}
 }
@@ -234,7 +233,7 @@ func (c *PseudonymsysClient) ObtainCredential(userSecret *big.Int,
 		}
 	}
 
-	err = errors.New("Organization failed to prove that a credential is valid.")
+	err = fmt.Errorf("organization failed to prove that a credential is valid")
 	return nil, err
 }
 

--- a/client/pseudonymsys_ec.go
+++ b/client/pseudonymsys_ec.go
@@ -18,7 +18,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -135,7 +134,7 @@ func (c *PseudonymsysClientEC) GenerateNym(userSecret *big.Int,
 		// todo: store in some DB: (orgName, nymA, nymB)
 		return pseudonymsys.NewPseudonymEC(nymA, nymB), nil
 	} else {
-		err := errors.New("The proof for nym registration failed.")
+		err := fmt.Errorf("proof for nym registration failed")
 		return nil, err
 	}
 }
@@ -253,7 +252,7 @@ func (c *PseudonymsysClientEC) ObtainCredential(userSecret *big.Int,
 		return nil, err
 	}
 
-	err = errors.New("Organization failed to prove that a credential is valid.")
+	err = fmt.Errorf("organization failed to prove that a credential is valid")
 	return nil, err
 }
 

--- a/client/qnr.go
+++ b/client/qnr.go
@@ -18,7 +18,6 @@
 package client
 
 import (
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -95,7 +94,7 @@ func (c *QNRClient) Run() (bool, error) {
 
 		verifierIsHonest := c.prover.Verify(pairs, verProofPairs)
 		if !verifierIsHonest {
-			err := errors.New("verifier is not honest")
+			err := fmt.Errorf("verifier is not honest")
 			return false, err
 		}
 

--- a/client/schnorr.go
+++ b/client/schnorr.go
@@ -109,12 +109,12 @@ func (c *SchnorrClient) runZeroKnowledge() error {
 
 	if success := c.prover.PedersenReceiver.CheckDecommitment(r, challenge); success {
 		proved, err := c.getProofData(challenge)
-		logger.Noticef("Decommitment successful, proved: %v", proved)
+		logger.Noticef("decommitment successful, proved: %v", proved)
 		if err != nil {
 			return err
 		}
 	} else {
-		return fmt.Errorf("Decommitment failed")
+		return fmt.Errorf("decommitment failed")
 	}
 
 	return nil

--- a/client/schnorr_ec.go
+++ b/client/schnorr_ec.go
@@ -45,7 +45,7 @@ func NewSchnorrECClient(conn *grpc.ClientConn, variant pb.SchemaVariant, curve g
 
 	prover, err := dlogproofs.NewSchnorrECProver(curve, variant.GetNativeType())
 	if err != nil {
-		return nil, fmt.Errorf("Could not create schnorr EC prover: %v", err)
+		return nil, fmt.Errorf("could not create schnorr EC prover: %v", err)
 	}
 
 	return &SchnorrECClient{
@@ -111,12 +111,12 @@ func (c *SchnorrECClient) runZeroKnowledge() error {
 	success := c.prover.PedersenReceiver.CheckDecommitment(r, challenge)
 	if success {
 		proved, err := c.getProofData(challenge)
-		logger.Noticef("Decommitment successful, proved: %v", proved)
+		logger.Noticef("decommitment successful, proved: %v", proved)
 		if err != nil {
 			return err
 		}
 	} else {
-		return fmt.Errorf("Decommitment failed")
+		return fmt.Errorf("decommitment failed")
 	}
 
 	return nil

--- a/config/config.go
+++ b/config/config.go
@@ -39,7 +39,7 @@ func LoadConfig(configName string, configType string) {
 
 	err := viper.ReadInConfig()
 	if err != nil {
-		panic(fmt.Errorf("Cannot read configuration file: %s\n", err))
+		panic(fmt.Errorf("cannot read configuration file: %s\n", err))
 	}
 }
 
@@ -89,7 +89,7 @@ func LoadQRRSA(name string) *groups.QRRSA {
 	q, _ := new(big.Int).SetString(x["q"].(string), 10)
 	qr, err := groups.NewQRRSA(p, q)
 	if err != nil {
-		panic(fmt.Errorf("Error when loading QRRSA RSA group: %s\n", err))
+		panic(fmt.Errorf("error when loading QRRSA RSA group: %s\n", err))
 	}
 	return qr
 }

--- a/crypto/commitments/damgard-fujisaki.go
+++ b/crypto/commitments/damgard-fujisaki.go
@@ -18,7 +18,7 @@
 package commitments
 
 import (
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/xlab-si/emmy/crypto/common"
@@ -44,7 +44,7 @@ func NewDamgardFujisakiCommitter(n, h, g *big.Int) *DamgardFujisakiCommitter {
 func (committer *DamgardFujisakiCommitter) GetCommitMsg(a *big.Int) (*big.Int, error) {
 	group := committer.QRSpecialRSA
 	if a.Cmp(group.N) != -1 {
-		err := errors.New("the committed value needs to be < N") // TODO: boundary to be checked
+		err := fmt.Errorf("the committed value needs to be < N") // TODO: boundary to be checked
 		return nil, err
 	}
 	// c = g^a * h^r % group.N

--- a/crypto/commitments/pedersen.go
+++ b/crypto/commitments/pedersen.go
@@ -18,8 +18,9 @@
 package commitments
 
 import (
-	"errors"
 	"math/big"
+
+	"fmt"
 
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
@@ -55,7 +56,7 @@ func (committer *PedersenCommitter) SetH(h *big.Int) {
 // It receives a value x (to this value a commitment is made), chooses a random x, outputs c = g^x * g^r.
 func (committer *PedersenCommitter) GetCommitMsg(val *big.Int) (*big.Int, error) {
 	if val.Cmp(committer.group.Q) == 1 || val.Cmp(big.NewInt(0)) == -1 {
-		err := errors.New("the committed value needs to be in Z_q (order of a base point)")
+		err := fmt.Errorf("committed value needs to be in Z_q (order of a base point)")
 		return nil, err
 	}
 

--- a/crypto/commitments/pedersen_ec.go
+++ b/crypto/commitments/pedersen_ec.go
@@ -18,7 +18,7 @@
 package commitments
 
 import (
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/xlab-si/emmy/crypto/common"
@@ -51,7 +51,7 @@ func (committer *PedersenECCommitter) SetH(h *groups.ECGroupElement) {
 // It receives a value x (to this value a commitment is made), chooses a random x, outputs c = g^x * g^r.
 func (committer *PedersenECCommitter) GetCommitMsg(val *big.Int) (*groups.ECGroupElement, error) {
 	if val.Cmp(committer.group.Q) == 1 || val.Cmp(big.NewInt(0)) == -1 {
-		err := errors.New("the committed value needs to be in Z_q (order of a base point)")
+		err := fmt.Errorf("the committed value needs to be in Z_q (order of a base point)")
 		return nil, err
 	}
 

--- a/crypto/commitments/rsa_based.go
+++ b/crypto/commitments/rsa_based.go
@@ -19,7 +19,6 @@ package commitments
 
 import (
 	"crypto/rand"
-	"errors"
 	"fmt"
 	"math/big"
 
@@ -78,7 +77,7 @@ func NewRSABasedCommitter(homomorphism func(*big.Int) *big.Int, homomorphismInv 
 	// Note that for other q-one-way homomorphisms this validation would be different:
 	yIsValid := H.IsElementInGroup(y)
 	if !yIsValid {
-		return nil, fmt.Errorf("Y is not valid")
+		return nil, fmt.Errorf("y is not valid")
 	}
 	return &RSABasedCommitter{
 		Homomorphism:    homomorphism,
@@ -91,7 +90,7 @@ func NewRSABasedCommitter(homomorphism func(*big.Int) *big.Int, homomorphismInv 
 
 func (committer *RSABasedCommitter) GetCommitMsg(a *big.Int) (*big.Int, error) {
 	if a.Cmp(committer.Q) != -1 {
-		err := errors.New("the committed value needs to be < Q")
+		err := fmt.Errorf("the committed value needs to be < Q")
 		return nil, err
 	}
 	c, r := committer.computeCommitment(a)

--- a/crypto/common/common.go
+++ b/crypto/common/common.go
@@ -19,7 +19,7 @@ package common
 
 import (
 	"crypto/sha512"
-	"errors"
+	"fmt"
 	"math/big"
 )
 
@@ -75,7 +75,7 @@ func LCM(x, y *big.Int) *big.Int {
 // It works only when p is prime.
 func IsQuadraticResidue(a *big.Int, p *big.Int) (bool, error) {
 	if !p.ProbablyPrime(20) {
-		err := errors.New("p is not prime")
+		err := fmt.Errorf("p is not a prime")
 		return false, err
 	}
 
@@ -89,7 +89,7 @@ func IsQuadraticResidue(a *big.Int, p *big.Int) (bool, error) {
 	} else if cr.Cmp(new(big.Int).Sub(p, big.NewInt(1))) == 0 {
 		return false, nil
 	} else {
-		err := errors.New("seems that p is not prime")
+		err := fmt.Errorf("it seems that p is not a prime")
 		return false, err
 	}
 }

--- a/crypto/common/group_generators.go
+++ b/crypto/common/group_generators.go
@@ -18,7 +18,7 @@
 package common
 
 import (
-	"errors"
+	"fmt"
 	"math/big"
 )
 
@@ -26,7 +26,7 @@ import (
 // Parameter groupOrder is order of Z_n (if n is prime, order is n-1).
 func GetGeneratorOfZnSubgroup(n, groupOrder, subgroupOrder *big.Int) (*big.Int, error) {
 	if big.NewInt(0).Mod(groupOrder, subgroupOrder).Cmp(big.NewInt(0)) != 0 {
-		err := errors.New("subgroupOrder does not divide groupOrder")
+		err := fmt.Errorf("subgroupOrder does not divide groupOrder")
 		return nil, err
 	}
 	r := new(big.Int).Div(groupOrder, subgroupOrder)

--- a/crypto/common/primes.go
+++ b/crypto/common/primes.go
@@ -19,7 +19,7 @@ package common
 
 import (
 	"crypto/rand"
-	"errors"
+	"fmt"
 	"io"
 	"math/big"
 )
@@ -34,7 +34,7 @@ func GetSafePrime(bits int) (p *big.Int, err error) {
 	if p.BitLen() == bits {
 		return p, nil
 	} else {
-		err := errors.New("bit length not correct")
+		err := fmt.Errorf("bit length not correct")
 		return nil, err
 	}
 }
@@ -70,7 +70,7 @@ func GetSpecialRSAPrimes(bits int) (*SpecialRSAPrimes, error) {
 	if p.BitLen() == bits && q.BitLen() == bits {
 		return NewSpecialRSAPrimes(p, q, p1, q1), nil
 	} else {
-		err := errors.New("bit length not correct")
+		err := fmt.Errorf("bit length not correct")
 		return NewSpecialRSAPrimes(nil, nil, nil, nil), err
 	}
 }
@@ -110,7 +110,7 @@ func germainPrime(bits int, c chan *big.Int, quit chan int) (p *big.Int, err err
 	rand := rand.Reader
 
 	if bits < 2 {
-		err = errors.New("crypto/rand: prime size must be at least 2-bit")
+		err = fmt.Errorf("crypto/rand: prime size must be at least 2-bit")
 		return
 	}
 

--- a/crypto/common/random.go
+++ b/crypto/common/random.go
@@ -19,7 +19,7 @@ package common
 
 import (
 	"crypto/rand"
-	"errors"
+	"fmt"
 	"log"
 	"math/big"
 )
@@ -36,7 +36,7 @@ func GetRandomInt(max *big.Int) *big.Int {
 // Returns random integer from [min, max).
 func GetRandomIntFromRange(min, max *big.Int) (*big.Int, error) {
 	if min.Cmp(max) >= 0 {
-		err := errors.New("GetRandomIntFromRange: max has to be bigger than min")
+		err := fmt.Errorf("GetRandomIntFromRange: max has to be bigger than min")
 		return nil, err
 	}
 	if min.Cmp(big.NewInt(0)) < 0 && max.Cmp(big.NewInt(0)) < 0 {

--- a/crypto/encryption/cs_paillier.go
+++ b/crypto/encryption/cs_paillier.go
@@ -18,7 +18,7 @@
 package encryption
 
 import (
-	"errors"
+	"fmt"
 	"log"
 	"math/big"
 
@@ -270,7 +270,7 @@ func (cspaillier *CSPaillier) StorePubKey(path string) error {
 // Returns (u, e, v).
 func (cspaillier *CSPaillier) Encrypt(m, label *big.Int) (*big.Int, *big.Int, *big.Int, error) {
 	if m.Cmp(cspaillier.PubKey.N) >= 0 {
-		err := errors.New("msg is too big")
+		err := fmt.Errorf("msg is too big")
 		return nil, nil, nil, err
 	}
 
@@ -310,7 +310,7 @@ func (cspaillier *CSPaillier) Decrypt(u, e, v, label *big.Int) (*big.Int, error)
 	// check whether Abs(v) = v:
 	vAbs, _ := cspaillier.Abs(v)
 	if v.Cmp(vAbs) != 0 {
-		err := errors.New("v != abs(v)")
+		err := fmt.Errorf("v != abs(v)")
 		return nil, err
 	}
 
@@ -333,7 +333,7 @@ func (cspaillier *CSPaillier) Decrypt(u, e, v, label *big.Int) (*big.Int, error)
 	v2.Mod(v2, n2)
 
 	if t.Cmp(v2) != 0 {
-		err := errors.New("CSPaillier decryption failed 1")
+		err := fmt.Errorf("CSPaillier decryption failed 1")
 		return nil, err
 	}
 
@@ -348,7 +348,7 @@ func (cspaillier *CSPaillier) Decrypt(u, e, v, label *big.Int) (*big.Int, error)
 	m1minModulo := new(big.Int).Mod(m1min, cspaillier.PubKey.N)
 
 	if m1minModulo.Cmp(big.NewInt(0)) != 0 {
-		err := errors.New("CSPaillier decryption failed 2")
+		err := fmt.Errorf("CSPaillier decryption failed 2")
 		return nil, err
 	}
 
@@ -360,7 +360,7 @@ func (cspaillier *CSPaillier) Decrypt(u, e, v, label *big.Int) (*big.Int, error)
 func (cspaillier *CSPaillier) Abs(a *big.Int) (*big.Int, error) {
 	n2 := new(big.Int).Mul(cspaillier.PubKey.N, cspaillier.PubKey.N)
 	if a.Cmp(n2) >= 0 {
-		err := errors.New("value is too big for abs function")
+		err := fmt.Errorf("value is too big for abs function")
 		return nil, err
 	}
 	b := new(big.Int).Div(n2, big.NewInt(2))

--- a/crypto/encryption/paillier.go
+++ b/crypto/encryption/paillier.go
@@ -19,7 +19,7 @@ package encryption
 
 import (
 	"crypto/rand"
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/xlab-si/emmy/crypto/common"
@@ -61,7 +61,7 @@ func NewPubPaillier(pubKey *PaillierPubKey) *Paillier {
 
 func (paillier *Paillier) Encrypt(m *big.Int) (*big.Int, error) {
 	if m.Cmp(paillier.pubKey.n) >= 0 {
-		err := errors.New("msg is too big")
+		err := fmt.Errorf("msg is too big")
 		return nil, err
 	}
 
@@ -79,7 +79,7 @@ func (paillier *Paillier) Encrypt(m *big.Int) (*big.Int, error) {
 
 func (paillier *Paillier) Decrypt(c *big.Int) (*big.Int, error) {
 	if c.Cmp(paillier.pubKey.n2) >= 0 {
-		err := errors.New("cipertext is too big")
+		err := fmt.Errorf("cipertext is too big")
 		return nil, err
 	}
 

--- a/crypto/groups/qr_rsa.go
+++ b/crypto/groups/qr_rsa.go
@@ -18,8 +18,9 @@
 package groups
 
 import (
-	"errors"
 	"math/big"
+
+	"fmt"
 
 	"github.com/xlab-si/emmy/crypto/common"
 )
@@ -36,7 +37,7 @@ type QRRSA struct {
 
 func NewQRRSA(P, Q *big.Int) (*QRRSA, error) {
 	if !P.ProbablyPrime(20) || !Q.ProbablyPrime(20) {
-		return nil, errors.New("P and Q must be primes")
+		return nil, fmt.Errorf("P and Q must be primes")
 	}
 	pMin := new(big.Int).Sub(P, big.NewInt(1))
 	pMinHalf := new(big.Int).Div(pMin, big.NewInt(2))
@@ -78,7 +79,7 @@ func (group *QRRSA) Exp(base, exponent *big.Int) *big.Int {
 func (group *QRRSA) IsElementInGroup(a *big.Int) (bool, error) {
 	if group.P == nil {
 		return false,
-			errors.New("IsElementInGroup not available for QRRSA with only public parameters")
+			fmt.Errorf("IsElementInGroup not available for QRRSA with only public parameters")
 	}
 
 	factors := []*big.Int{group.P, group.Q}

--- a/crypto/groups/qr_special_rsa.go
+++ b/crypto/groups/qr_special_rsa.go
@@ -20,7 +20,7 @@ package groups
 // TODO: check group_generators.go and move the content into groups
 
 import (
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/xlab-si/emmy/crypto/common"
@@ -84,7 +84,7 @@ func (group *QRSpecialRSA) GetRandomGenerator() (*big.Int, error) {
 
 	if group.P == nil {
 		return nil,
-			errors.New("GetRandomGenerator not available for QRSpecialRSA with only public parameters")
+			fmt.Errorf("GetRandomGenerator not available for QRSpecialRSA with only public parameters")
 	}
 
 	for {
@@ -113,7 +113,7 @@ func (group *QRSpecialRSA) GetRandomGenerator() (*big.Int, error) {
 func (group *QRSpecialRSA) GetRandomElement() (*big.Int, error) {
 	if group.P == nil {
 		return nil,
-			errors.New("GetRandomElement not available for QRSpecialRSA with only public parameters")
+			fmt.Errorf("GetRandomElement not available for QRSpecialRSA with only public parameters")
 	}
 	g, err := group.GetRandomGenerator()
 	if err != nil {

--- a/crypto/groups/schnorr.go
+++ b/crypto/groups/schnorr.go
@@ -48,7 +48,7 @@ func NewSchnorrGroup(qBitLength int) (*SchnorrGroup, error) {
 	} else if qBitLength == 256 {
 		sizes = dsa.L2048N256
 	} else {
-		err := fmt.Errorf("Generating Schnorr primes for bit length %d is not supported", qBitLength)
+		err := fmt.Errorf("generating Schnorr primes for bit length %d is not supported", qBitLength)
 		return nil, err
 	}
 

--- a/crypto/secretsharing/dealer.go
+++ b/crypto/secretsharing/dealer.go
@@ -19,7 +19,7 @@ package secretsharing
 
 import (
 	"crypto/rand"
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/xlab-si/emmy/crypto/common"
@@ -38,11 +38,11 @@ func NewDealer() (*Dealer, error) {
 func (dealer *Dealer) SplitSecret(secret string, threshold int,
 	numberOfShares int) (map[*big.Int]*big.Int, *big.Int, error) {
 	if threshold < 2 {
-		err := errors.New("the threshold should be at least 2")
+		err := fmt.Errorf("the threshold should be at least 2")
 		return nil, nil, err
 	}
 	if threshold > numberOfShares {
-		err := errors.New("the threshold should be smaller than the number of shares")
+		err := fmt.Errorf("the threshold should be smaller than the number of shares")
 		return nil, nil, err
 	}
 
@@ -51,7 +51,7 @@ func (dealer *Dealer) SplitSecret(secret string, threshold int,
 
 	// generate some random prime which will be bigger than numberOfShares and secretNum
 	if secretNum.Cmp(big.NewInt(int64(numberOfShares))) < 0 {
-		err := errors.New("the number of shares (participants) is too high")
+		err := fmt.Errorf("the number of shares (participants) is too high")
 		return nil, nil, err
 	}
 
@@ -61,7 +61,7 @@ func (dealer *Dealer) SplitSecret(secret string, threshold int,
 	}
 
 	if prime.Cmp(big.NewInt(int64(numberOfShares))) < 0 {
-		err := errors.New("the number of shares (participants) is too high")
+		err := fmt.Errorf("the number of shares (participants) is too high")
 		return nil, nil, err
 	}
 

--- a/crypto/signatures/cl.go
+++ b/crypto/signatures/cl.go
@@ -19,9 +19,10 @@ package signatures
 
 import (
 	"crypto/rand"
-	"errors"
 	"log"
 	"math/big"
+
+	"fmt"
 
 	"github.com/xlab-si/emmy/crypto/common"
 )
@@ -105,14 +106,14 @@ func (cl *CL) getQuadraticResidues(n *big.Int) ([]*big.Int, *big.Int, *big.Int) 
 
 func (cl *CL) Sign(m_Ls []*big.Int) (*CLSignature, error) {
 	if cl.numOfBlocks != len(m_Ls) {
-		err := errors.New("the number of message blocks is not correct")
+		err := fmt.Errorf("number of message blocks is not correct")
 		return nil, err
 	}
 
 	// each m should be in [0, 2^l_m)
 	for _, m_L := range m_Ls {
 		if m_L.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m)), nil)) > -1 {
-			err := errors.New("msg is too big")
+			err := fmt.Errorf("msg is too big")
 			return nil, err
 		}
 	}
@@ -167,7 +168,7 @@ func (cl *CL) Verify(m_Ls []*big.Int, signature *CLSignature) (bool, error) {
 	// each m should be in [0, 2^l_m)
 	for _, m_L := range m_Ls {
 		if m_L.Cmp(new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(cl.config.l_m)), nil)) > -1 {
-			err := errors.New("msg is too big")
+			err := fmt.Errorf("msg is too big")
 			return false, err
 		}
 	}

--- a/crypto/zkp/primitives/qrproofs/qnr.go
+++ b/crypto/zkp/primitives/qrproofs/qnr.go
@@ -20,7 +20,7 @@ package qrproofs
 // Statistical zero-knowledge proof of quadratic non-residousity.
 
 import (
-	"errors"
+	"fmt"
 	"math/big"
 
 	"github.com/xlab-si/emmy/crypto/common"
@@ -44,7 +44,7 @@ func ProveQNR(y *big.Int, qr *groups.QRRSA) (bool, error) {
 
 		verifierIsHonest := prover.Verify(pairs, verProof)
 		if !verifierIsHonest {
-			err := errors.New("verifier is not honest")
+			err := fmt.Errorf("verifier is not honest")
 			return false, err
 		}
 

--- a/crypto/zkp/primitives/qrproofs/qr.go
+++ b/crypto/zkp/primitives/qrproofs/qr.go
@@ -20,8 +20,9 @@ package qrproofs
 // Zero-knowledge proof	of quadratic residousity (implemented for historical reasons)
 
 import (
-	"errors"
 	"math/big"
+
+	"fmt"
 
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
@@ -79,7 +80,7 @@ func (prover *QRProver) GetProofData(challenge *big.Int) (*big.Int, error) {
 		z.Mod(z, prover.Group.P)
 		return z, nil
 	} else {
-		err := errors.New("The challenge is not valid.")
+		err := fmt.Errorf("challenge is not valid")
 		return nil, err
 	}
 }

--- a/crypto/zkp/primitives/representationproofs/representation.go
+++ b/crypto/zkp/primitives/representationproofs/representation.go
@@ -82,7 +82,7 @@ type RepresentationProver struct {
 func NewRepresentationProver(group *groups.SchnorrGroup, secrets,
 	bases []*big.Int, y *big.Int) (*RepresentationProver, error) {
 	if len(secrets) != len(bases) {
-		return nil, fmt.Errorf("Number of secrets and representation bases shoud be the same.")
+		return nil, fmt.Errorf("number of secrets and representation bases shoud be the same")
 	}
 
 	return &RepresentationProver{

--- a/crypto/zkp/schemes/pseudonymsys/ca.go
+++ b/crypto/zkp/schemes/pseudonymsys/ca.go
@@ -93,6 +93,6 @@ func (ca *CA) Verify(z *big.Int) (*CACertificate, error) {
 			return NewCACertificate(blindedA, blindedB, r, s), nil
 		}
 	} else {
-		return nil, fmt.Errorf("The knowledge of secret was not verified.")
+		return nil, fmt.Errorf("knowledge of secret was not verified")
 	}
 }

--- a/crypto/zkp/schemes/pseudonymsys/ca_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/ca_ec.go
@@ -94,6 +94,6 @@ func (ca *CAEC) Verify(z *big.Int) (*CACertificateEC, error) {
 			return NewCACertificateEC(blindedA, blindedB, r, s), nil
 		}
 	} else {
-		return nil, fmt.Errorf("The knowledge of secret was not verified.")
+		return nil, fmt.Errorf("knowledge of secret was not verified")
 	}
 }

--- a/crypto/zkp/schemes/pseudonymsys/org_issue.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_issue.go
@@ -18,8 +18,9 @@
 package pseudonymsys
 
 import (
-	"errors"
 	"math/big"
+
+	"fmt"
 
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
@@ -115,7 +116,7 @@ func (org *OrgCredentialIssuer) VerifyAuthentication(z *big.Int) (
 
 		return x11, x12, x21, x22, A, B, nil
 	} else {
-		err := errors.New("Authentication with organization failed")
+		err := fmt.Errorf("authentication with organization failed")
 		return nil, nil, nil, nil, nil, nil, err
 	}
 }

--- a/crypto/zkp/schemes/pseudonymsys/org_issue_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_issue_ec.go
@@ -18,8 +18,9 @@
 package pseudonymsys
 
 import (
-	"errors"
 	"math/big"
+
+	"fmt"
 
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
@@ -118,7 +119,7 @@ func (org *OrgCredentialIssuerEC) VerifyAuthentication(z *big.Int) (
 
 		return x11, x12, x21, x22, A, B, nil
 	} else {
-		err := errors.New("Authentication with organization failed")
+		err := fmt.Errorf("authentication with organization failed")
 		return nil, nil, nil, nil, nil, nil, err
 	}
 }

--- a/crypto/zkp/schemes/pseudonymsys/org_nym_gen.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_nym_gen.go
@@ -66,7 +66,7 @@ func (org *OrgNymGen) GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2,
 		challenge := org.EqualityVerifier.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2)
 		return challenge, nil
 	} else {
-		return nil, fmt.Errorf("The signature is not valid.")
+		return nil, fmt.Errorf("signature is not valid")
 	}
 }
 

--- a/crypto/zkp/schemes/pseudonymsys/org_nym_gen_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_nym_gen_ec.go
@@ -68,7 +68,7 @@ func (org *OrgNymGenEC) GetChallenge(nymA, blindedA, nymB, blindedB,
 		challenge := org.EqualityVerifier.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2)
 		return challenge, nil
 	} else {
-		return nil, fmt.Errorf("The signature is not valid.")
+		return nil, fmt.Errorf("signature is not valid")
 	}
 }
 

--- a/server/qnr.go
+++ b/server/qnr.go
@@ -51,7 +51,7 @@ func (s *Server) QNR(req *pb.Message, qr *groups.QRRSA,
 		}
 
 		if req.GetEmpty() == nil {
-			return fmt.Errorf("Shoud receive empty message at this point")
+			return fmt.Errorf("should receive empty message at this point")
 		}
 
 		w, pairs := verifier.GetChallenge()

--- a/server/server.go
+++ b/server/server.go
@@ -106,7 +106,7 @@ func (s *Server) Start(port int) error {
 	connStr := fmt.Sprintf(":%d", port)
 	listener, err := net.Listen("tcp", connStr)
 	if err != nil {
-		return fmt.Errorf("Could not connect: %v", err)
+		return fmt.Errorf("could not connect: %v", err)
 	}
 
 	// Register Prometheus metrics handler and serve metrics page on the desired endpoint.
@@ -141,7 +141,7 @@ func (s *Server) EnableTracing() {
 
 func (s *Server) send(msg *pb.Message, stream pb.Protocol_RunServer) error {
 	if err := stream.Send(msg); err != nil {
-		return fmt.Errorf("Error sending message: %v", err)
+		return fmt.Errorf("error sending message: %v", err)
 	}
 	s.logger.Infof("Successfully sent response of type %T", msg.Content)
 	s.logger.Debugf("%+v", msg)
@@ -154,7 +154,7 @@ func (s *Server) receive(stream pb.Protocol_RunServer) (*pb.Message, error) {
 	if err == io.EOF {
 		return nil, err
 	} else if err != nil {
-		return nil, fmt.Errorf("An error ocurred: %v", err)
+		return nil, fmt.Errorf("an error ocurred: %v", err)
 	}
 	s.logger.Infof("Received request of type %T from the stream", resp.Content)
 	s.logger.Debugf("%+v", resp)
@@ -177,13 +177,13 @@ func (s *Server) Run(stream pb.Protocol_RunServer) error {
 	// Check whether the client requested a valid schema
 	reqSchemaTypeStr, schemaValid := pb.SchemaType_name[int32(reqSchemaType)]
 	if !schemaValid {
-		return fmt.Errorf("Client [ %d ] requested invalid schema: %v", reqClientId, reqSchemaType)
+		return fmt.Errorf("client [ %d ] requested invalid schema: %v", reqClientId, reqSchemaType)
 	}
 
 	// Check whether the client requested a valid schema variant
 	reqSchemaVariantStr, variantValid := pb.SchemaVariant_name[int32(reqSchemaVariant)]
 	if !variantValid {
-		return fmt.Errorf("Client [ %d ] requested invalid schema variant: %v", reqClientId, reqSchemaVariant)
+		return fmt.Errorf("client [ %d ] requested invalid schema variant: %v", reqClientId, reqSchemaVariant)
 	}
 
 	s.logger.Noticef("Client [ %v ] requested schema %v, variant %v", reqClientId, reqSchemaTypeStr, reqSchemaVariantStr)
@@ -234,7 +234,7 @@ func (s *Server) Run(stream pb.Protocol_RunServer) error {
 
 	if err != nil {
 		s.logger.Error("Closing RPC due to previous errors")
-		return fmt.Errorf("FAIL: %v", err)
+		return fmt.Errorf("RPC call failed: %v", err)
 	}
 
 	s.logger.Notice("RPC finished successfully")

--- a/server/session.go
+++ b/server/session.go
@@ -19,7 +19,7 @@ type sessionKey string
 func newSessionManager(n int) (*sessionManager, error) {
 	var err error
 	if n < MIN_SESSION_KEY_BYTE_LEN {
-		err = fmt.Errorf("The desired length of the session key (%d B) is too short. Falling back to %d B.",
+		err = fmt.Errorf("desired length of the session key (%d B) is too short, falling back to %d B",
 			n, MIN_SESSION_KEY_BYTE_LEN)
 		n = MIN_SESSION_KEY_BYTE_LEN
 	}


### PR DESCRIPTION
This commit re-formats error messages in `fmt.Errorf()` calls in order to conform to [code review recommendations for formatting error messages in Go](https://github.com/golang/go/wiki/CodeReviewComments#error-strings).

All the errors are now produced with `fmt.Errorf()` to achieve better consistency across the project. Calls to `errors.New()` were removed in favor of `fmt.Errorf()` calls.

I propose we follow the same convention (e.g. the use of `fmt.Errorf()` for definition of errors, and using short error messages starting with lower-cased letters and no punctuation at the end) in all new additions to the project. If you agree, we should "enforce" this during code review for all the subsequent PRs :slightly_smiling_face: 