### PR TITLE
Add redis address CLI flag to emmy server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Alternatively, you can control emmy server's behavior with the following options
 
 4. **Certificate and private key**: flags *--cert* and *--key*, whose value is a path to a valid certificate and private key in PEM format. These will be used to secure communication channel with clients. Please refer to [explanation of TLS support in Emmy](#tls-support) for explanation.
 
+5. **Address of the redis database**: flag *--db* of the form *redisHost:redisPort*, which points
+ to a running instance of redis database that holds [registration keys](#registration-keys). 
+ Defaults to *localhost:6379*.
+
 Starting the server should produce an output similar to the one below:
 
 ```

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -86,6 +86,13 @@ var serverEndpointFlag = cli.StringFlag{
 	Usage: "`URI` of emmy server in the form serverHost:serverPort",
 }
 
+// dbEndpointFlag points to the endpoint at which emmy server will contact redis database.
+var dbEndpointFlag = cli.StringFlag{
+	Name:  "db",
+	Value: config.LoadRegistrationDBAddress(),
+	Usage: "`URI` of redis database to hold registration keys, in the form redisHost:redisPort",
+}
+
 // nClientsFlag indicates the number of (either concurrent or sequential) clients to run.
 var nClientsFlag = cli.IntFlag{
 	Name:  "nclients, n",
@@ -131,6 +138,7 @@ var serverFlags = []cli.Flag{
 	portFlag,
 	certFlag,
 	keyFlag,
+	dbEndpointFlag,
 	logFilePathFlag,
 	logLevelFlag,
 }

--- a/cli/server.go
+++ b/cli/server.go
@@ -36,6 +36,7 @@ var ServerCmd = cli.Command{
 					ctx.Int("port"),
 					ctx.String("cert"),
 					ctx.String("key"),
+					ctx.String("db"),
 					ctx.String("logfile"),
 					ctx.String("loglevel"))
 				if err != nil {
@@ -48,7 +49,7 @@ var ServerCmd = cli.Command{
 }
 
 // startEmmyServer configures and starts the gRPC server at the desired port
-func startEmmyServer(port int, certPath, keyPath, logFilePath, logLevel string) error {
+func startEmmyServer(port int, certPath, keyPath, dbAddress, logFilePath, logLevel string) error {
 	var err error
 	var logger log.Logger
 
@@ -62,7 +63,7 @@ func startEmmyServer(port int, certPath, keyPath, logFilePath, logLevel string) 
 		return err
 	}
 
-	srv, err := server.NewProtocolServer(certPath, keyPath, logger)
+	srv, err := server.NewProtocolServer(certPath, keyPath, dbAddress, logger)
 	if err != nil {
 		return err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/log"
 	"github.com/xlab-si/emmy/server"
 	"google.golang.org/grpc"
@@ -38,7 +39,8 @@ var testGrpcClientConn *grpc.ClientConn
 // Once all the tests run, we close the connection to the server and stop the server.
 func TestMain(m *testing.M) {
 	logger, _ := log.NewStdoutLogger("testServer", log.NOTICE, log.FORMAT_LONG)
-	server, err := server.NewProtocolServer("testdata/server.pem", "testdata/server.key", logger)
+	server, err := server.NewProtocolServer("testdata/server.pem", "testdata/server.key",
+		config.LoadRegistrationDBAddress(), logger)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/server/registration_manager.go
+++ b/server/registration_manager.go
@@ -18,6 +18,8 @@
 package server
 
 import (
+	"fmt"
+
 	"github.com/go-redis/redis"
 )
 
@@ -31,7 +33,7 @@ func NewRegistrationManager(address string) (*registrationManager, error) {
 	})
 	err := redisClient.Ping().Err()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to connect to redis database (%s)", err)
 	}
 	return &registrationManager{redisClient}, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -48,7 +48,8 @@ type Server struct {
 // It performs some default configuration (tracing of gRPC communication and interceptors)
 // and registers RPC protocol server with gRPC server. It requires TLS cert and keyfile
 // in order to establish a secure channel with clients.
-func NewProtocolServer(certFile, keyFile string, logger log.Logger) (*Server, error) {
+func NewProtocolServer(certFile, keyFile, dbAddress string, logger log.Logger) (*Server,
+	error) {
 	logger.Info("Instantiating new protocol server")
 
 	// Register our generic service
@@ -67,9 +68,9 @@ func NewProtocolServer(certFile, keyFile string, logger log.Logger) (*Server, er
 		logger.Warning(err)
 	}
 
-	registrationManager, err := NewRegistrationManager(config.LoadRegistrationDBAddress())
+	registrationManager, err := NewRegistrationManager(dbAddress)
 	if err != nil {
-		logger.Error(err)
+		logger.Critical(err)
 		return nil, err
 	}
 


### PR DESCRIPTION
This PR adds a new `--db` flag to `emmy server` CLI command. The flag should point to the address of the redis database that will hold registration keys. This allows us to override the default value (read from `config/defaults.yml`) at server startup. 

Address of the redis database is now also passed to the initializer of the `Server` struct. 

At the same time, since it's all very minor and related, this PR also:
* updates the README with updated instructions (description of the `--db` flag),
* increases logged severity of not being able to connect to redis at a given address to *critical*,
* improves the error message that gets reported when server cannot connect to redis instance at startup.