### PR TITLE
Improve server-side handling of protocol errors

### DIFF
--- a/server/pseudonymsys.go
+++ b/server/pseudonymsys.go
@@ -46,7 +46,7 @@ func (s *Server) PseudonymsysGenerateNym(req *pb.Message, stream pb.Protocol_Run
 	var resp *pb.Message
 
 	if !regKeyOk || err != nil {
-		s.logger.Errorf("registration key %s ok=%t, error=%v",
+		s.logger.Debugf("registration key %s ok=%t, error=%v",
 			proofRandData.RegKey, regKeyOk, err)
 		resp = &pb.Message{
 			ProtocolError: "registration key verification failed",
@@ -58,7 +58,7 @@ func (s *Server) PseudonymsysGenerateNym(req *pb.Message, stream pb.Protocol_Run
 	} else {
 		challenge, err := org.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2, signatureR, signatureS)
 		if err != nil {
-			s.logger.Error(err)
+			s.logger.Debug(err)
 			resp = &pb.Message{
 				ProtocolError: err.Error(),
 			}
@@ -130,7 +130,7 @@ func (s *Server) PseudonymsysIssueCredential(req *pb.Message, stream pb.Protocol
 
 	x11, x12, x21, x22, A, B, err := org.VerifyAuthentication(z)
 	if err != nil {
-		s.logger.Error(err)
+		s.logger.Debug(err)
 		resp = &pb.Message{
 			ProtocolError: err.Error(),
 		}
@@ -248,7 +248,7 @@ func (s *Server) PseudonymsysTransferCredential(req *pb.Message, stream pb.Proto
 	if verified {
 		sessionKey, err := s.generateSessionKey()
 		if err != nil {
-			s.logger.Error(err)
+			s.logger.Debug(err)
 			resp.ProtocolError = "failed to obtain session key"
 		} else {
 			resp.Content = &pb.Message_SessionKey{
@@ -258,7 +258,7 @@ func (s *Server) PseudonymsysTransferCredential(req *pb.Message, stream pb.Proto
 			}
 		}
 	} else {
-		s.logger.Error("User authentication failed")
+		s.logger.Debug("User authentication failed")
 		resp.ProtocolError = "user authentication failed"
 	}
 

--- a/server/pseudonymsys.go
+++ b/server/pseudonymsys.go
@@ -46,9 +46,10 @@ func (s *Server) PseudonymsysGenerateNym(req *pb.Message, stream pb.Protocol_Run
 	var resp *pb.Message
 
 	if !regKeyOk || err != nil {
+		s.logger.Errorf("registration key %s ok=%t, error=%v",
+			proofRandData.RegKey, regKeyOk, err)
 		resp = &pb.Message{
-			Content:       nil,
-			ProtocolError: "Registration key verification failed",
+			ProtocolError: "registration key verification failed",
 		}
 
 		if err = s.send(resp, stream); err != nil {
@@ -57,10 +58,8 @@ func (s *Server) PseudonymsysGenerateNym(req *pb.Message, stream pb.Protocol_Run
 	} else {
 		challenge, err := org.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2, signatureR, signatureS)
 		if err != nil {
+			s.logger.Error(err)
 			resp = &pb.Message{
-				Content: &pb.Message_PedersenDecommitment{
-					&pb.PedersenDecommitment{},
-				},
 				ProtocolError: err.Error(),
 			}
 		} else {
@@ -131,10 +130,8 @@ func (s *Server) PseudonymsysIssueCredential(req *pb.Message, stream pb.Protocol
 
 	x11, x12, x21, x22, A, B, err := org.VerifyAuthentication(z)
 	if err != nil {
+		s.logger.Error(err)
 		resp = &pb.Message{
-			Content: &pb.Message_PseudonymsysIssueProofRandomData{
-				&pb.PseudonymsysIssueProofRandomData{},
-			},
 			ProtocolError: err.Error(),
 		}
 	} else {
@@ -251,8 +248,8 @@ func (s *Server) PseudonymsysTransferCredential(req *pb.Message, stream pb.Proto
 	if verified {
 		sessionKey, err := s.generateSessionKey()
 		if err != nil {
-			resp.ProtocolError = err.Error()
-			s.logger.Notice(err)
+			s.logger.Error(err)
+			resp.ProtocolError = "failed to obtain session key"
 		} else {
 			resp.Content = &pb.Message_SessionKey{
 				SessionKey: &pb.SessionKey{
@@ -261,7 +258,8 @@ func (s *Server) PseudonymsysTransferCredential(req *pb.Message, stream pb.Proto
 			}
 		}
 	} else {
-		resp.ProtocolError = "User authentication failed"
+		s.logger.Error("User authentication failed")
+		resp.ProtocolError = "user authentication failed"
 	}
 
 	if err = s.send(resp, stream); err != nil {

--- a/server/pseudonymsys_ca.go
+++ b/server/pseudonymsys_ca.go
@@ -72,7 +72,7 @@ func (s *Server) PseudonymsysCA(req *pb.Message, stream pb.Protocol_RunServer) e
 			},
 		}
 	} else {
-		s.logger.Error(err)
+		s.logger.Debug(err)
 		resp = &pb.Message{
 			ProtocolError: err.Error(),
 		}

--- a/server/pseudonymsys_ca.go
+++ b/server/pseudonymsys_ca.go
@@ -72,10 +72,8 @@ func (s *Server) PseudonymsysCA(req *pb.Message, stream pb.Protocol_RunServer) e
 			},
 		}
 	} else {
+		s.logger.Error(err)
 		resp = &pb.Message{
-			Content: &pb.Message_PseudonymsysCaCertificate{
-				&pb.PseudonymsysCACertificate{},
-			},
 			ProtocolError: err.Error(),
 		}
 	}

--- a/server/pseudonymsys_ca_ec.go
+++ b/server/pseudonymsys_ca_ec.go
@@ -73,10 +73,8 @@ func (s *Server) PseudonymsysCAEC(curveType groups.ECurve, req *pb.Message,
 			},
 		}
 	} else {
+		s.logger.Error(err)
 		resp = &pb.Message{
-			Content: &pb.Message_PseudonymsysCaCertificateEc{
-				&pb.PseudonymsysCACertificateEC{},
-			},
 			ProtocolError: err.Error(),
 		}
 	}

--- a/server/pseudonymsys_ca_ec.go
+++ b/server/pseudonymsys_ca_ec.go
@@ -73,7 +73,7 @@ func (s *Server) PseudonymsysCAEC(curveType groups.ECurve, req *pb.Message,
 			},
 		}
 	} else {
-		s.logger.Error(err)
+		s.logger.Debug(err)
 		resp = &pb.Message{
 			ProtocolError: err.Error(),
 		}

--- a/server/pseudonymsys_ec.go
+++ b/server/pseudonymsys_ec.go
@@ -47,7 +47,7 @@ func (s *Server) PseudonymsysGenerateNymEC(curveType groups.ECurve, req *pb.Mess
 	var resp *pb.Message
 
 	if !regKeyOk || err != nil {
-		s.logger.Errorf("Registration key %s ok=%t, error=%v",
+		s.logger.Debugf("Registration key %s ok=%t, error=%v",
 			proofRandData.RegKey, regKeyOk, err)
 		resp = &pb.Message{
 			ProtocolError: "registration key verification failed",
@@ -59,7 +59,7 @@ func (s *Server) PseudonymsysGenerateNymEC(curveType groups.ECurve, req *pb.Mess
 	} else {
 		challenge, err := org.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2, signatureR, signatureS)
 		if err != nil {
-			s.logger.Error(err)
+			s.logger.Debug(err)
 			resp = &pb.Message{
 				ProtocolError: err.Error(),
 			}
@@ -132,7 +132,7 @@ func (s *Server) PseudonymsysIssueCredentialEC(curveType groups.ECurve, req *pb.
 	x11, x12, x21, x22, A, B, err := org.VerifyAuthentication(z)
 
 	if err != nil {
-		s.logger.Error(err)
+		s.logger.Debug(err)
 		resp = &pb.Message{
 			ProtocolError: err.Error(),
 		}
@@ -254,7 +254,7 @@ func (s *Server) PseudonymsysTransferCredentialEC(curveType groups.ECurve, req *
 	if verified {
 		sessionKey, err := s.generateSessionKey()
 		if err != nil {
-			s.logger.Error(err)
+			s.logger.Debug(err)
 			resp.ProtocolError = "failed to obtain session key"
 		} else {
 			resp.Content = &pb.Message_SessionKey{
@@ -264,7 +264,7 @@ func (s *Server) PseudonymsysTransferCredentialEC(curveType groups.ECurve, req *
 			}
 		}
 	} else {
-		s.logger.Error("User authentication failed")
+		s.logger.Debug("User authentication failed")
 		resp.ProtocolError = "user authentication failed"
 	}
 

--- a/server/server.go
+++ b/server/server.go
@@ -143,7 +143,11 @@ func (s *Server) send(msg *pb.Message, stream pb.Protocol_RunServer) error {
 	if err := stream.Send(msg); err != nil {
 		return fmt.Errorf("error sending message: %v", err)
 	}
-	s.logger.Infof("Successfully sent response of type %T", msg.Content)
+	if msg.ProtocolError != "" {
+		s.logger.Infof("Successfully sent response of type %T", msg.ProtocolError)
+	} else {
+		s.logger.Infof("Successfully sent response of type %T", msg.Content)
+	}
 	s.logger.Debugf("%+v", msg)
 
 	return nil


### PR DESCRIPTION
This PR improves the way protocol errors are handled by emmy server.

So far, we only reported `ProtocolError`s back to the client in case any of pseudonym system protocols failed. However, these errors were not consistently logged at the server side. Here's a summary of changes:
* added logging for all `ProtocolError`s at the server side with the *error* severity level - so far we were only able to see these errors in one of the protocols, and only if the log level of `Server`'s logger was *debug*. Now we'll be able to detect these errors more quickly, as they will be shown in the server's log even if it's not running in debugging mode.
* the `Server`'s `send()` function is updated to more precisely log the type of message that was sent (either `msg.Content` or `msg.ProtocolError`). 
* some unnecessary payload initialization (passing something like `Content: nil` or even `Content: &pb.SomeType{}` to initialization of `pb.Message`) in case of protocol error ocurred was also removed.
