### PR TITLE
Add short colorless format to logging formats

### DIFF
--- a/log/formats.go
+++ b/log/formats.go
@@ -6,6 +6,10 @@ const (
 	// GetConnection ▶ INFO  Getting the connection
 	FORMAT_SHORT = `%{color}%{shortfunc} ▶ %{level} %{color:reset} %{message}`
 
+	// Same as FORMAT_SHORT but without the color information.
+	// Appropriate for logging to files or on mobile clients.
+	FORMAT_SHORT_COLORLESS = `%{shortfunc} ▶ %{level} %{message}`
+
 	// Convenient to use with server loggers, where we need more fine-grained info and readable
 	// output (includes color information, useful for console output)
 	// [server][Mon 25.Sep 2017,14:11:041] Start ▶ NOTI  Emmy server listening for connections on port 7007


### PR DESCRIPTION
This commit adds a definition of `FORMAT_SHORT_COLORLESS` to `log/formats.go`. It is analogous to our existing `FORMAT_SHORT`, but doesn't contain any color information. This is especially appropriate for logging on mobile clients, where color information is not needed (or not interpreted at all, which is why we get unwanted symbols displayed among the logging messages).
