### PR TITLE
Implement GenerateMasterNym functions

### DIFF
--- a/client/pseudonymsys_ca_ec.go
+++ b/client/pseudonymsys_ca_ec.go
@@ -31,6 +31,7 @@ import (
 type PseudonymsysCAClientEC struct {
 	genericClient
 	grpcClient pb.PseudonymSystemCAClient
+	curve      groups.ECurve
 	prover     *dlogproofs.SchnorrECProver
 }
 
@@ -43,8 +44,17 @@ func NewPseudonymsysCAClientEC(conn *grpc.ClientConn, curve groups.ECurve) (*Pse
 	return &PseudonymsysCAClientEC{
 		genericClient: newGenericClient(),
 		grpcClient:    pb.NewPseudonymSystemCAClient(conn),
+		curve:         curve,
 		prover:        prover,
 	}, nil
+}
+
+// GenerateMasterNym generates a master pseudonym to be used with GenerateCertificate.
+func (c *PseudonymsysCAClientEC) GenerateMasterNym(secret *big.Int) *pseudonymsys.PseudonymEC {
+	group := groups.NewECGroup(c.curve)
+	a := groups.NewECGroupElement(group.Curve.Params().Gx, group.Curve.Params().Gy)
+	b := group.Exp(a, secret)
+	return pseudonymsys.NewPseudonymEC(a, b)
 }
 
 // GenerateCertificate provides a certificate from trusted CA to the user. Note that CA

--- a/client/pseudonymsys_ec_test.go
+++ b/client/pseudonymsys_ec_test.go
@@ -29,7 +29,6 @@ import (
 
 func TestPseudonymsysEC(t *testing.T) {
 	curveType := groups.P256
-	group := groups.NewECGroup(curveType)
 	caClient, err := NewPseudonymsysCAClientEC(testGrpcClientConn, curveType)
 	if err != nil {
 		t.Errorf("Error when initializing NewPseudonymsysCAClientEC")
@@ -39,10 +38,7 @@ func TestPseudonymsysEC(t *testing.T) {
 	c1, err := NewPseudonymsysClientEC(testGrpcClientConn, curveType)
 	userSecret := c1.GenerateMasterKey()
 
-	nymA := groups.NewECGroupElement(group.Curve.Params().Gx, group.Curve.Params().Gy)
-	nymB := group.Exp(nymA, userSecret) // this is user's public key
-
-	masterNym := pseudonymsys.NewPseudonymEC(nymA, nymB)
+	masterNym := caClient.GenerateMasterNym(userSecret)
 	caCertificate, err := caClient.GenerateCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA: %s", err.Error())

--- a/client/pseudonymsys_test.go
+++ b/client/pseudonymsys_test.go
@@ -30,7 +30,6 @@ import (
 
 // TestPseudonymsys requires a running server (it is started in communication_test.go).
 func TestPseudonymsys(t *testing.T) {
-	group := config.LoadGroup("pseudonymsys")
 	caClient, err := NewPseudonymsysCAClient(testGrpcClientConn)
 	if err != nil {
 		t.Errorf("Error when initializing NewPseudonymsysCAClient")
@@ -40,8 +39,7 @@ func TestPseudonymsys(t *testing.T) {
 	c1, err := NewPseudonymsysClient(testGrpcClientConn)
 	userSecret := c1.GenerateMasterKey()
 
-	p := group.Exp(group.G, userSecret) // this is user's public key
-	masterNym := pseudonymsys.NewPseudonym(group.G, p)
+	masterNym := caClient.GenerateMasterNym(userSecret)
 	caCertificate, err := caClient.GenerateCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA")


### PR DESCRIPTION
This commit adds `GenerateMasterNym` function to `PseudonymsysCAClient` and `PseudonymsysCAClientEC` in order to simplify master pseudonym generation for the client.

Logic for master nym generation was moved from pseudonymsys test code and replaced with calls to newly introduced functions.