### PR TITLE
Add Dockerfile and docker-compose file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+#
+# Copyright 2017 XLAB d.o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+FROM golang:latest
+
+LABEL maintainer="XLAB d.o.o" \
+      description="This image starts the core Emmy server"
+
+# Create appropriate directory structure
+RUN mkdir -p $GOPATH/src/github.com/xlab-si/emmy
+
+# Run subsequent commands from the project root
+WORKDIR $GOPATH/src/github.com/xlab-si/emmy
+
+# Copy project from host to project directory in container
+COPY ./ ./
+
+# Install dependencies and compile the project
+RUN go get -t ./... && \
+    go install
+
+# Start emmy server
+ENTRYPOINT ["emmy", "server", "start"]
+
+# Set default arguments for entrypoint command
+CMD ["--loglevel", "debug", "--db", "redis:6379"]
+
+EXPOSE 7007

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+#
+# Copyright 2017 XLAB d.o.o.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+version: '3'
+
+services:
+  emmy-server:
+    container_name: emmy-server
+    build:
+      context: .
+    ports:
+    - "7007:7007"
+    depends_on:
+    - redis
+
+  redis:
+    container_name: emmy-redis
+    image: redis:latest
+    ports:
+    - "6379:6379"

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -19,7 +19,18 @@ spin up an instance of emmy server.
 In addition, we provide a *docker-compose.yml* file you can use to start both emmy server as well as
 a redis database to hold registration keys. Note that registration keys need to exist in redis 
 beforehand; emmy server only checks for their existence, while a separate entity needs to insert
-them into redis (either you put them there manually, or some third party application has to).
+them into redis (either you put them there manually, or some third party application has to). The
+example below shows how a sample registration key can be inserted into the dockerized instance of
+the redis database:
+
+````bash
+$ docker exec -it emmy-redis redis-cli set testRegKey abcdef;
+OK
+````
+In the command above *emmy-redis* is the name of the redis container (as specified in the
+*docker-compose.yml* file), while *redis-cli set testRegKey abcdef* is the command that will be executed
+from within the redis container. The result of this command is insertion of a key *testRegKey* with the
+value *abcdef*, that has no expiration time set.
 
 By default, emmy server will be started in debug mode, but you can modify `emmy-server` service in the
 *docker-compose.yml* and provide your own `command` to override the emmy server startup command.

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -12,6 +12,27 @@ Go into the root project folder and execute:
 $ protoc -I protobuf/ protobuf/messages.proto protobuf/services.proto protobuf/enums.proto --go_out=plugins=grpc:protobuf
 ```
 
+# Using dockerized Emmy server and redis for development
+For testing and ease of development this repository comes with a *Dockerfile* that you can use to 
+spin up an instance of emmy server. 
+
+In addition, we provide a *docker-compose.yml* file you can use to start both emmy server as well as
+a redis database to hold registration keys. Note that registration keys need to exist in redis 
+beforehand; emmy server only checks for their existence, while a separate entity needs to insert
+them into redis (either you put them there manually, or some third party application has to).
+
+By default, emmy server will be started in debug mode, but you can modify `emmy-server` service in the
+*docker-compose.yml* and provide your own `command` to override the emmy server startup command.
+
+To start both emmy server and redis, run:
+````bash
+$ docker-compose up
+````
+Or, if you just want emmy server without redis, you can run:
+````bash
+$ docker-compose up emmy-server
+````
+
 # Mobile clients
 Emmy comes with compatibility layer that allows us to re-use some of the library's 
 functionality on mobile clients. Currently, we support running **pseudonym system (both modular and


### PR DESCRIPTION
This commit adds a Dockerfile for building emmy server image. In addition, docker-compose file is added that starts emmy server container as well as redis container. 

These are added solely for convenience during development; the use of dockerized components is not assumed during unit testing on a given host or for Travis CI builds.

Brief guidelines and instructions were added to `docs/develop.md`.