### PR TITLE
Implement Lipmaa's decomposition of non-negative integers

### DIFF
--- a/crypto/common/decomposition.go
+++ b/crypto/common/decomposition.go
@@ -1,0 +1,316 @@
+/*
+ * Copyright 2017 XLAB d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package common
+
+import (
+	"fmt"
+	"math/big"
+)
+
+// Common values used for comparisons and big integer arithmetic, defined here for convenience.
+var (
+	zero = big.NewInt(0)
+	one  = big.NewInt(1)
+	two  = big.NewInt(2)
+	four = big.NewInt(4)
+)
+
+// Lagrange is an array that will hold the roots of the decomposed integer.
+// It has exactly 4 elements - if decomposition has less than four roots, the remaining
+// ones are set to zero.
+type Lagrange [4]*big.Int
+
+// NewLagrange initializes Lagrange array with zero values
+func NewLagrange() Lagrange {
+	w := Lagrange{}
+	for i := 0; i < 4; i++ {
+		w[i] = new(big.Int).Set(zero)
+	}
+	return w
+}
+
+func (l Lagrange) Set(w0, w1, w2, w3 *big.Int) {
+	l[0].Set(w0)
+	l[1].Set(w1)
+	l[2].Set(w2)
+	l[3].Set(w3)
+}
+
+// LipmaaDecomposition takes a positive integer and computes its lagrange representation as the
+// sum of (at most) four squares.
+// Returns the roots of the decomposed integer - when squared, they sum up to exactly n.
+func LipmaaDecomposition(n *big.Int) (Lagrange, error) {
+	// roots of the decomposed integer
+	var w Lagrange
+	var err error
+
+	isSpecial, w, err := getSpecialDecomposition(n)
+	if err != nil {
+		return w, err
+	}
+	if isSpecial {
+		return w, nil
+	}
+
+	// Write n in the form 2^t(2k+1), where t,k >= 0
+	// t is the index (starting at LSB) of the first set bit
+	t := 0
+	for n.Bit(t) == 0 {
+		t++
+	}
+	k := new(big.Int).Rsh(n, uint(t+1))
+
+	if t == 1 {
+		p, w1, w2 := findPrimeAndTwoRoots(n)
+		sqrtOfMinus1 := sqrtOfMinus1(p)
+		w3, w4 := decomposePrimeToTwoSquares(sqrtOfMinus1, p)
+		w.Set(w1, w2, w3, w4)
+
+	} else if t%2 == 1 {
+		// if t is odd but not 1, find a representation (w1,w2,w3,w4) of integer m
+		// and return representation of integer n = (sw1,sw2,sw3,sw4), where s = 2^((t-1)/2).
+		e := uint(t-1) / 2 // exponent of s
+		m := new(big.Int).Rsh(n, uint(t-1))
+
+		// recurse to find representation (w1,w2,w3,w4) of integer m
+		w, err = LipmaaDecomposition(m)
+		if err != nil {
+			return w, err
+		}
+		// because s is a power of two (e.g. s = 2^((t-1)/2) = 2^e), multiplication with s
+		// is equivalent to performing e = (t-1)/2 left shifts
+		w[0].Lsh(w[0], e)
+		w[1].Lsh(w[1], e)
+		w[2].Lsh(w[2], e)
+		w[3].Lsh(w[3], e)
+	} else {
+		// if t is even, first find a representation (w1,w2,w3,w4) of integer m = 2(2k+1)
+		m := new(big.Int).Mul(k, four)
+		m.Add(m, two)
+
+		// recurse to find representation (w1,w2,w3,w4) of integer m
+		wM, err := LipmaaDecomposition(m)
+		if err != nil {
+			return w, err
+		}
+
+		// group the roots of decomposed integer m into a representation (w1,w2,w3,w4)
+		// so that w1 is congruent w2 mod 2 and w3 is congruent w4 mod 2 (e.g. w1-w2 and w3-w4 are
+		// both divisible by 2). This way we get the representation of 2k+1 instead of
+		// representation for 2(2k+1)
+		if wM[0].Bit(0) == wM[1].Bit(0) { // w1 and w2 are both odd, OK
+			w = wM
+		}
+		if wM[0].Bit(0) == wM[2].Bit(0) { //
+			w = wM
+			tmp := new(big.Int).Set(wM[2])
+			wM[2].Set(wM[1])
+			wM[1].Set(tmp)
+		}
+		if wM[0].Bit(0) == wM[3].Bit(0) {
+			w = wM
+			tmp := new(big.Int).Set(wM[3])
+			wM[3].Set(wM[1])
+			wM[1].Set(tmp)
+		}
+
+		// return representation of n = (s(w1+w2), s(w1-w2), s(w3+w4), s(w3-w4))
+		// where s = 2^(t/2-1)
+		w1Plusw2 := new(big.Int).Add(w[0], w[1])
+		w1Minusw2 := new(big.Int).Sub(w[0], w[1])
+		w3Plusw4 := new(big.Int).Add(w[2], w[3])
+		w3Minusw4 := new(big.Int).Sub(w[2], w[3])
+
+		if t/2-1 >= 0 {
+			e := big.NewInt(int64(t/2 - 1))
+			s := new(big.Int).Exp(two, e, nil)
+			w.Set(new(big.Int).Mul(w1Plusw2, s),
+				new(big.Int).Mul(w1Minusw2, s),
+				new(big.Int).Mul(w3Plusw4, s),
+				new(big.Int).Mul(w3Minusw4, s))
+
+		} else { // t/2-1 < 0
+			w.Set(new(big.Int).Div(w1Plusw2, two),
+				new(big.Int).Div(w1Minusw2, two),
+				new(big.Int).Div(w3Plusw4, two),
+				new(big.Int).Div(w3Minusw4, two))
+		}
+	}
+
+	for i := 0; i < 4; i++ {
+		w[i].Abs(w[i])
+	}
+
+	return w, nil
+}
+
+// getSpecialDecomposition checks for validity of integral argument and returns decomposition of a
+// special case (0, 1 and 2) if aporopriate. Otherwise it returns a zero-filled decomposition.
+func getSpecialDecomposition(n *big.Int) (bool, Lagrange, error) {
+	w := NewLagrange()
+
+	if n.Cmp(zero) < 0 {
+		return true, w, fmt.Errorf("n cannot be negative")
+	}
+
+	if n.Cmp(zero) == 0 {
+		return true, w, nil
+	}
+	if n.Cmp(one) == 0 {
+		w[0].Set(one)
+		return true, w, nil
+	}
+	if n.Cmp(two) == 0 {
+		w[0].Set(one)
+		w[1].Set(one)
+		return true, w, nil
+	}
+
+	return false, w, nil
+}
+
+// findPrimeAndTwoRoots finds such a prime p = n-w1²-w2² that p is congruent to 1 modulo 4
+// (e.g. p-1 is divisible by 4), given randomly selected w1 <= sqrt(n) and w2 <= sqrt(n - w1²),
+// where exactly one of w1, w2 is even.
+// w1 and w2 are also returned as two of the roots of n's decomposition.
+func findPrimeAndTwoRoots(n *big.Int) (*big.Int, *big.Int, *big.Int) {
+	// we will need to get random w1, w2 within appropriate upper boundaries
+	w1, w2 := new(big.Int), new(big.Int)
+	w1Upper, w2Upper := new(big.Int), new(big.Int)
+
+	w1Upper.Sqrt(n) // upper bound for w1 is sqrt(n)
+
+	p := new(big.Int)
+	// repeat the procedure until we're fairly confident that p really is a prime
+	for !p.ProbablyPrime(20) {
+		// choose random w1 <= sqrt(n)
+		w1 = GetRandomInt(w1Upper)
+
+		// choose random w2 <= sqrt(n - w1²)
+		w2Upper.Sqrt(new(big.Int).Sub(n, new(big.Int).Mul(w1, w1)))
+		w2 = GetRandomInt(w2Upper)
+
+		// we need to ensure that exactly one of w1, w2 is even
+		if w1.Bit(0) == w2.Bit(0) {
+			w1.Sub(w1, one) // decrease w1 by one to obtain an odd number
+			if w1.Cmp(zero) <= 0 {
+				continue
+			}
+		}
+
+		// p = n - w1² - w2²
+		p.Sub(n, new(big.Int).Mul(w1, w1))
+		p.Sub(p, new(big.Int).Mul(w2, w2))
+	}
+
+	return p, w1, w2
+}
+
+// decomposePrimeToTwoSquares aplies partial Euclidean algorithm over integers in
+// order to obtain such x and y that produce p = x²+y² for a prime p.
+// x and y are obtained as the two largest remainders that are less than sqrt(p).
+func decomposePrimeToTwoSquares(u, p *big.Int) (*big.Int, *big.Int) {
+	a := new(big.Int).Set(u)
+	b := new(big.Int).Set(p)
+	r := new(big.Int).Mod(a, b)
+
+	x := new(big.Int).Set(a)
+	y := new(big.Int).Set(r)
+	sqrtP := new(big.Int).Sqrt(p)
+
+	for x.Cmp(sqrtP) > 0 || x.Cmp(y) == 0 {
+		x.Set(a)
+		y.Set(r)
+		r.Mod(a, b)
+
+		a.Set(b)
+		b.Set(r)
+	}
+
+	return x, y
+}
+
+// sqrtOfMinus1 efficiently computes the square root of -1 modulo p,
+// where p is a prime.
+func sqrtOfMinus1(p *big.Int) *big.Int {
+	if p.Cmp(one) == 0 {
+		return zero
+	}
+	if p.Cmp(two) == 0 {
+		return one
+	}
+
+	u := new(big.Int).Sub(p, one) // u = p-1
+	k := new(big.Int).Set(u)
+
+	var s uint = 0
+	for k.Bit(int(s)) == 0 {
+		s++
+	}
+
+	k.Rsh(k, uint(s))
+	k.Sub(k, one)
+	k.Rsh(k, 1)
+
+	r := new(big.Int).Exp(u, k, p)
+
+	n := new(big.Int).Exp(r, two, nil)
+	n.Rem(n, p)
+	n.Mul(n, u)
+	n.Rem(n, p)
+
+	r.Mul(r, u)
+	r.Rem(r, p)
+
+	if n.Cmp(one) == 0 {
+		return r
+	}
+
+	z := new(big.Int).Set(two)
+	for new(big.Int).Exp(z, new(big.Int).Div(new(big.Int).Sub(p, one), two), p).Cmp(one) == 0 {
+		z.Add(z, one)
+	}
+
+	v := new(big.Int).Set(k)
+	v.Lsh(v, 1)
+	v.Add(v, one)
+
+	c := new(big.Int).Exp(z, v, p)
+
+	var t uint = 0
+	for n.Cmp(one) > 0 {
+		k.Set(n)
+		t = s
+		s = 0
+
+		for k.Cmp(one) != 0 {
+			k.Mod(new(big.Int).Exp(k, two, nil), p)
+			s++
+		}
+		t -= s
+
+		v.Set(one)
+		v.Lsh(v, t-1)
+		c.Exp(c, v, p)
+		r.Rem(new(big.Int).Mul(r, c), p)
+		c.Rem(new(big.Int).Mul(c, c), p)
+		n.Mod(new(big.Int).Mul(n, c), p)
+	}
+
+	return r
+}

--- a/crypto/common/decomposition_test.go
+++ b/crypto/common/decomposition_test.go
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2017 XLAB d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package common
+
+import (
+	"math/big"
+	"testing"
+)
+
+// TestLipmaaDecompositionNegativeInteger tests whether decomposition function returns an error
+// when an invaid argument (negative integer) is provided.
+func TestLipmaaDecompositionNegativeInteger(t *testing.T) {
+	integer := big.NewInt(-1)
+	_, err := LipmaaDecomposition(integer)
+	if err == nil {
+		t.Errorf("decomposition of negative integer should produce an error")
+	}
+}
+
+// TestLipmaaDecompositionWithSmallIntegers iteratively tests whether the roots of retrieved
+// decompositions sum up exactly to a given integer when they are squared.
+func TestLipmaaDecompositionWithSmallIntegers(t *testing.T) {
+	var bigInt = new(big.Int)
+	for i := 0; i <= 10000; i++ {
+		bigInt.SetInt64(int64(i))
+		roots, _ := LipmaaDecomposition(bigInt)
+		squaredRootsSum := squareRootsAndSum(roots)
+		if bigInt.Cmp(squaredRootsSum) != 0 {
+			t.Errorf("decomposition does not work correctly for small integers ("+
+				"expected root to sum up to %d, got %d)", bigInt.Int64(), squaredRootsSum.Int64())
+		}
+	}
+}
+
+// TestLipmaaDecompositionWithBigInteger tests whether decomposition works for a large integer.
+func TestLipmaaDecompositionWithBigInteger(t *testing.T) {
+	bigInt, _ := new(big.Int).SetString("16714772973240639959372252262788596420406994288943442724185217359247384753656472309049760952976644136858333233015922583099687128195321947212684779063190875332970679291085543110146729439665070418750765330192961290161474133279960593149307037455272278582955789954847238104228800942225108143276152223829168166008095539967222363070565697796008563529948374781419181195126018918350805639881625937503224895840081959848677868603567824611344898153185576740445411565094067875133968946677861528581074542082733743513314354002186235230287355796577107626422168586230066573268163712626444511811717579062108697723640288393001520781671", 10)
+	roots, _ := LipmaaDecomposition(bigInt)
+	if squareRootsAndSum(roots).Cmp(bigInt) != 0 {
+		t.Errorf("decomposition does not work correctly for a large integer")
+	}
+
+}
+
+// squareRootsAndSum calculates the sum of squares for a given lagrangian.
+func squareRootsAndSum(w Lagrange) *big.Int {
+	sum := new(big.Int)
+	for _, root := range w {
+		sum.Add(sum, new(big.Int).Mul(root, root))
+	}
+
+	return sum
+}


### PR DESCRIPTION
This commit adds implementation of Lipmaa's algorithm for calculating the lagrangian of a given non-negative integer, as described in [this paper](https://www.iacr.org/cryptodb/archive/2003/ASIACRYPT/353/353.pdf). 

Given an arbitrary non-negative integer *n*, the algorithm efficiently computes the roots *w<sub>1</sub>, w<sub>2</sub>, w<sub>3</sub>, w<sub>4</sub>*, so that, when squared, the roots add up to exactly *n* (*n = w<sub>1</sub><sup>2</sup> + w<sub>2</sub><sup>2</sup> + w<sub>3</sub><sup>2</sup> + w<sub>4</sub><sup>2</sup>*).

This algorithm will be used in the future to support implementation of range proofs.