### PR TITLE
Pseudonymsys clients' initializers accept group parameter

### DIFF
--- a/client/compatibility/group.go
+++ b/client/compatibility/group.go
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017 XLAB d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package compatibility
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/groups"
+)
+
+// SchnorrGroup represents an equivalent of groups.SchnorrGroup, but has string
+// field types to overcome type restrictions of Go language binding tools.
+type SchnorrGroup struct {
+	P string
+	G string
+	Q string
+}
+
+func NewSchnorrGroup(p, g, q string) *SchnorrGroup {
+	return &SchnorrGroup{
+		P: p,
+		G: g,
+		Q: q,
+	}
+}
+
+func (sg *SchnorrGroup) toNativeType() (*groups.SchnorrGroup, error) {
+	p, pOk := new(big.Int).SetString(sg.P, 10)
+	g, gOk := new(big.Int).SetString(sg.G, 10)
+	q, qOk := new(big.Int).SetString(sg.Q, 10)
+
+	if !pOk || !gOk || !qOk {
+		return nil, fmt.Errorf("groups's p, g or q: %s", ArgsConversionError)
+	}
+
+	group := groups.NewSchnorrGroupFromParams(p, g, q)
+	return group, nil
+}

--- a/client/compatibility/pseudonymsys.go
+++ b/client/compatibility/pseudonymsys.go
@@ -137,8 +137,14 @@ type PseudonymsysClient struct {
 	*client.PseudonymsysClient
 }
 
-func NewPseudonymsysClient(conn *Connection) (*PseudonymsysClient, error) {
-	c, err := client.NewPseudonymsysClient(conn.ClientConn)
+func NewPseudonymsysClient(conn *Connection, g *SchnorrGroup) (*PseudonymsysClient, error) {
+	// Translate SchnorrGroup
+	group, err := g.toNativeType()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := client.NewPseudonymsysClient(conn.ClientConn, group)
 	if err != nil {
 		return nil, err
 	}

--- a/client/compatibility/pseudonymsys_ca.go
+++ b/client/compatibility/pseudonymsys_ca.go
@@ -91,8 +91,14 @@ type PseudonymsysCAClient struct {
 	*client.PseudonymsysCAClient
 }
 
-func NewPseudonymsysCAClient(conn *Connection) (*PseudonymsysCAClient, error) {
-	c, err := client.NewPseudonymsysCAClient(conn.ClientConn)
+func NewPseudonymsysCAClient(conn *Connection, g *SchnorrGroup) (*PseudonymsysCAClient, error) {
+	// Translate SchnorrGroup
+	group, err := g.toNativeType()
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := client.NewPseudonymsysCAClient(conn.ClientConn, group)
 	if err != nil {
 		return nil, err
 	}

--- a/client/pseudonymsys.go
+++ b/client/pseudonymsys.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/common"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
@@ -37,9 +36,8 @@ type PseudonymsysClient struct {
 	group      *groups.SchnorrGroup
 }
 
-func NewPseudonymsysClient(conn *grpc.ClientConn) (*PseudonymsysClient, error) {
-	group := config.LoadSchnorrGroup()
-
+func NewPseudonymsysClient(conn *grpc.ClientConn,
+	group *groups.SchnorrGroup) (*PseudonymsysClient, error) {
 	return &PseudonymsysClient{
 		group:         group,
 		genericClient: newGenericClient(),

--- a/client/pseudonymsys_ca.go
+++ b/client/pseudonymsys_ca.go
@@ -20,7 +20,6 @@ package client
 import (
 	"math/big"
 
-	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/groups"
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/crypto/zkp/protocoltypes"
@@ -36,9 +35,8 @@ type PseudonymsysCAClient struct {
 	prover     *dlogproofs.SchnorrProver
 }
 
-func NewPseudonymsysCAClient(conn *grpc.ClientConn) (*PseudonymsysCAClient, error) {
-	group := config.LoadSchnorrGroup()
-
+func NewPseudonymsysCAClient(conn *grpc.ClientConn,
+	group *groups.SchnorrGroup) (*PseudonymsysCAClient, error) {
 	return &PseudonymsysCAClient{
 		genericClient: newGenericClient(),
 		grpcClient:    pb.NewPseudonymSystemCAClient(conn),

--- a/client/pseudonymsys_test.go
+++ b/client/pseudonymsys_test.go
@@ -30,13 +30,15 @@ import (
 
 // TestPseudonymsys requires a running server (it is started in communication_test.go).
 func TestPseudonymsys(t *testing.T) {
-	caClient, err := NewPseudonymsysCAClient(testGrpcClientConn)
+	group := config.LoadSchnorrGroup()
+
+	caClient, err := NewPseudonymsysCAClient(testGrpcClientConn, group)
 	if err != nil {
 		t.Errorf("Error when initializing NewPseudonymsysCAClient")
 	}
 
 	// usually the endpoint is different from the one used for CA:
-	c1, err := NewPseudonymsysClient(testGrpcClientConn)
+	c1, err := NewPseudonymsysClient(testGrpcClientConn, group)
 	userSecret := c1.GenerateMasterKey()
 
 	masterNym := caClient.GenerateMasterNym(userSecret)
@@ -73,7 +75,7 @@ func TestPseudonymsys(t *testing.T) {
 
 	// register with org2
 	// create a client to communicate with org2
-	caClient1, err := NewPseudonymsysCAClient(testGrpcClientConn)
+	caClient1, err := NewPseudonymsysCAClient(testGrpcClientConn, group)
 	caCertificate1, err := caClient1.GenerateCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA: %s", err.Error())
@@ -82,7 +84,7 @@ func TestPseudonymsys(t *testing.T) {
 	// c2 connects to the same server as c1, so what we're really testing here is
 	// using transferCredential to authenticate with the same organization and not
 	// transferring credentials to another organization
-	c2, err := NewPseudonymsysClient(testGrpcClientConn)
+	c2, err := NewPseudonymsysClient(testGrpcClientConn, group)
 	nym2, err := c2.GenerateNym(userSecret, caCertificate1, "testRegKey2")
 	if err != nil {
 		t.Errorf(err.Error())


### PR DESCRIPTION
This PR slightly modifies `PseudonymsysClient` and `PseudonymsysCAClient` initializer functions by adding a parameter of type `groups.SchnorrGroup`.

Until now, initializer functions merely constructed schnorr group from the values provided in the configuration file (or, for mobile clients, which had no means of passing their own configuration file, the defaults were loaded). Schnorr group is now generated externally and passed to  both initializers. This allows mobile clients to specify their own (non-default) schnorr group, which was previously not possible.

PS: This is how it's already done for all other clients as well - if a protocol needs `SchnorrGroup`, then it is constructed outside and passed to initializer, for instance see `NewQRClient`, `NewSchnorrClient` and others in the `client` package.