### PR TITLE
Use Makefile for a simplified build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,6 @@ services:
   - docker
 
 go:
-  #- 1.6
-  #- 1.7
-  #- 1.8
   - tip
 
 go_import_path: github.com/xlab-si/emmy
@@ -15,11 +12,11 @@ before_install:
   - docker run -d --rm -p 127.0.0.1:6379:6379 --name emmy-redis redis
 
 install:
-  - go get github.com/stretchr/testify/assert
+  - make setup_test
   - go get -u -t github.com/$TRAVIS_REPO_SLUG
   
 script: 
-  - go test -v ./...
+  - make test
 
 after_script:
   - docker stop emmy-redis

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,62 @@
+.PHONY: setup setup_test setup_mobile setup_linter install test fmt lint android proto clean run
+
+ALL=./...
+
+all: install
+
+# Setup and update all the required tools
+setup: setup_test setup_linter setup_mobile
+
+setup_test:
+	go get -u github.com/stretchr/testify/assert
+
+setup_mobile:
+	go get -u golang.org/x/mobile/cmd/gomobile
+
+setup_linter:
+	go get -u github.com/alecthomas/gometalinter
+	gometalinter --install --update
+
+# Install go package to produce emmy binaries
+install:
+	go install
+
+# Run test for all packages and report test coverage status
+test:
+	go test -v -cover $(ALL)
+
+# Lists and formats all go source files with goimports
+fmt:
+	# List of files with different formatting than goimport's
+	goimports -l .
+	goimports -w .
+
+# Displays output from several linters
+# Auto-generated code for protobuffers is excluded from this check
+lint:
+	-gometalinter --exclude=.*.pb.go \
+	 	--enable=gofmt \
+		--enable=goimports \
+		--enable=gosimple \
+		--enable=misspell \
+		$(ALL)
+
+# Generates Android archive (AAR) for emmy's client compatibility package
+android:
+	gomobile bind -v -o emmy.aar github.com/xlab-si/emmy/client/compatibility
+
+# Generates protobuffer code based on protobuffer definitions
+# Requires protoc compiler
+proto:
+	protoc -I protobuf/ \
+ 	 	protobuf/messages.proto \
+ 	 	protobuf/services.proto \
+ 	 	protobuf/enums.proto \
+ 	 	--go_out=plugins=grpc:protobuf
+
+# Removes temporary files produced by the targets
+clean:
+	-rm emmy.aar emmy-sources.jar
+
+run:
+	docker-compose up --build

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ setup_test:
 
 setup_mobile:
 	go get -u golang.org/x/mobile/cmd/gomobile
+	gomobile init
 
 setup_linter:
 	go get -u github.com/alecthomas/gometalinter
@@ -58,5 +59,6 @@ proto:
 clean:
 	-rm emmy.aar emmy-sources.jar
 
+# Rebuilds emmy server and starts emmy server and redis instance
 run:
 	docker-compose up --build

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -1,16 +1,62 @@
 # Emmy - development
 
+To speed up frequent development tasks and preparation of development environment, this 
+repository comes with a *Makefile* and a *docker-compose.yml* file. You can use
+* **Makefile** to install and run useful development tools, while
+* **docker-compose.yml** can be used to quickly prepare development environment.
+
+## Using Makefile
+When using Makefile for the first time, you should run `make setup`. This will install or update 
+go tools like [gometalinter](https://github.com/alecthomas/gometalinter) that you *should* learn 
+to use on a regular basis. You should re-run `make setup` once in a while to keep these packages 
+up-to-date.
+
+Below we provide a brief description of the Makefile's targets, how and when to use them and how 
+they can aid the development.
+
+* `make` or `make install` will compile all the packages and produce `emmy` binary with `server` 
+and 
+`client` CLI commands.
+* `make test` will compile and run tests for all the packages and report test coverage.
+* `make fmt` will list the files whose formating does not conform to that of *goimports*, and fix 
+their formatting. See [Source code formatting](#source-code-formatting).
+* `make lint` will run *gometalinter* and display warnings from chosen linters for all go source 
+files in this repository except the auto-generated ones .
+* `make proto` will run *protoc* compiler in order to re-generate the protobuffer source code 
+from proto definitions in the protobuf package. See [Updating protocol buffers](#updating-protocol-buffers).
+* `make android` will generate Android archive that can be used to invoke compatible emmy clients
+ from an Android application. See [Mobile clients](#mobile-clients).
+* `make clean` will remove the files produced by `make android` command.
+* `make run` will rebuild and start all the services defined in the `docker-compose.yml` file 
+(currently these include emmy server and redis database instance). To have more control over what
+ services are started and how, you should consider running `docker-compose` and `docker` commands
+  directly - without `make`. For more details please see [Using 
+ dockerized Emmy server and redis for development](#using-dockerized-emmy-server-and-redis-for-development).
+
 ## Source code formatting
 All contributions to *emmy* library should conform to source formatting enforced by [goimports](https://godoc.org/golang.org/x/tools/cmd/goimports).
-Please install *goimports* and configure your source code editor to automatically run it on every file save.
+Please install *goimports* and configure your source code editor to automatically run it on every
+ file save. 
+ 
+ Alternatively, you can manually run `make fmt` before submitting a PR. This command will first 
+ list the files whose formatting does not conform to *goimports* formatting, and then fix the 
+ formatting of all go source files in the repository.  
 
-## To compile .proto files
+## Updating protocol buffers
+Emmy uses protocol buffers for communication. Definitions of services, RPCs and payloads can be 
+found in **.proto* files of the `protobuf` package. We need these definitions and [protoc 
+compiler](https://developers
+.google.com/protocol-buffers/docs/downloads) in order to obtain appropriate go source files 
+with definition of types, functions and interfaces that we are able to import from other packages
+ later on.
 
-Go into the root project folder and execute:
+If definitions in *.proto* files changed, we need to re-generate the source code with *protoc* 
+compiler. This means we have to execute the following command from the root of the repository:
 
 ```bash
 $ protoc -I protobuf/ protobuf/messages.proto protobuf/services.proto protobuf/enums.proto --go_out=plugins=grpc:protobuf
 ```
+Alternatively, you can run `make proto` to re-generate the same files.
 
 # Using dockerized Emmy server and redis for development
 For testing and ease of development this repository comes with a *Dockerfile* that you can use to 
@@ -30,19 +76,25 @@ OK
 In the command above *emmy-redis* is the name of the redis container (as specified in the
 *docker-compose.yml* file), while *redis-cli set testRegKey abcdef* is the command that will be executed
 from within the redis container. The result of this command is insertion of a key *testRegKey* with the
-value *abcdef*, that has no expiration time set.
+value *abcdef*, that has no expiration time set. Note that the current version of emmy server 
+only checks the presence of a specific key (in this case *testRegKey*) and does not care about 
+the corresponding value.
 
 By default, emmy server will be started in debug mode, but you can modify `emmy-server` service in the
 *docker-compose.yml* and provide your own `command` to override the emmy server startup command.
 
-To start both emmy server and redis, run:
+To (re)build and start both emmy server and redis, run:
 ````bash
-$ docker-compose up
+$ docker-compose up --build
 ````
+> This is equivalent to running `make run`
+
 Or, if you just want emmy server without redis, you can run:
 ````bash
 $ docker-compose up emmy-server
 ````
+This will use the existing image of the emmy server to start the container, if one exists. 
+Otherwise the image will not be rebuilt.
 
 # Mobile clients
 Emmy comes with compatibility layer that allows us to re-use some of the library's 


### PR DESCRIPTION
This PR adds a *Makefile* with several targets for ease of testing and development. Instructions in the Travis CI file were updated so that `make` commands are used. 

Most importantly, documentation in `docs/develop` was also updated and improved on several places, so that the possibility of using `make` targets is reflected where appropriate.