### PR TITLE
Implement corrections suggested by linters

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -151,7 +151,7 @@ func (c *genericClient) receive() (*pb.Message, error) {
 	if err == io.EOF {
 		return nil, fmt.Errorf("[client %v] EOF error", c.id)
 	} else if err != nil {
-		return nil, fmt.Errorf("[client %v] An error ocurred: %v", c.id, err)
+		return nil, fmt.Errorf("[client %v] An error occurred: %v", c.id, err)
 	}
 	if resp.ProtocolError != "" {
 		return nil, fmt.Errorf(resp.ProtocolError)

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 	}
 
 	// Configure a custom logger for the client package
-	clientLogger, err := log.NewStdoutLogger("client", log.NOTICE, log.FORMAT_SHORT)
+	clientLogger, _ := log.NewStdoutLogger("client", log.NOTICE, log.FORMAT_SHORT)
 	SetLogger(clientLogger)
 
 	go server.Start(7008)

--- a/client/pedersen.go
+++ b/client/pedersen.go
@@ -64,7 +64,7 @@ func (c *PedersenClient) Run() error {
 
 	commitment, err := c.committer.GetCommitMsg(c.val)
 	if err != nil {
-		logger.Criticalf("could not generate committment message: %v", err)
+		logger.Criticalf("could not generate commitment message: %v", err)
 		return err
 	}
 

--- a/client/pedersen_ec.go
+++ b/client/pedersen_ec.go
@@ -60,7 +60,7 @@ func (c *PedersenECClient) Run() error {
 
 	commitment, err := c.committer.GetCommitMsg(c.val)
 	if err != nil {
-		logger.Criticalf("could not generate committment message: %v", err)
+		logger.Criticalf("could not generate commitment message: %v", err)
 		return nil
 	}
 

--- a/client/pseudonymsys_ec_test.go
+++ b/client/pseudonymsys_ec_test.go
@@ -35,7 +35,7 @@ func TestPseudonymsysEC(t *testing.T) {
 	}
 
 	// usually the endpoint is different from the one used for CA:
-	c1, err := NewPseudonymsysClientEC(testGrpcClientConn, curveType)
+	c1, _ := NewPseudonymsysClientEC(testGrpcClientConn, curveType)
 	userSecret := c1.GenerateMasterKey()
 
 	masterNym := caClient.GenerateMasterNym(userSecret)
@@ -74,7 +74,7 @@ func TestPseudonymsysEC(t *testing.T) {
 
 	// register with org2
 	// create a client to communicate with org2
-	caClient1, err := NewPseudonymsysCAClientEC(testGrpcClientConn, curveType)
+	caClient1, _ := NewPseudonymsysCAClientEC(testGrpcClientConn, curveType)
 	caCertificate1, err := caClient1.GenerateCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA")
@@ -83,7 +83,7 @@ func TestPseudonymsysEC(t *testing.T) {
 	// c2 connects to the same server as c1, so what we're really testing here is
 	// using transferCredential to authenticate with the same organization and not
 	// transferring credentials to another organization
-	c2, err := NewPseudonymsysClientEC(testGrpcClientConn, curveType)
+	c2, _ := NewPseudonymsysClientEC(testGrpcClientConn, curveType)
 	nym2, err := c2.GenerateNym(userSecret, caCertificate1, "testRegKey2")
 	if err != nil {
 		t.Errorf(err.Error())

--- a/client/pseudonymsys_test.go
+++ b/client/pseudonymsys_test.go
@@ -36,7 +36,7 @@ func TestPseudonymsys(t *testing.T) {
 	}
 
 	// usually the endpoint is different from the one used for CA:
-	c1, err := NewPseudonymsysClient(testGrpcClientConn)
+	c1, _ := NewPseudonymsysClient(testGrpcClientConn)
 	userSecret := c1.GenerateMasterKey()
 
 	masterNym := caClient.GenerateMasterNym(userSecret)
@@ -73,7 +73,7 @@ func TestPseudonymsys(t *testing.T) {
 
 	// register with org2
 	// create a client to communicate with org2
-	caClient1, err := NewPseudonymsysCAClient(testGrpcClientConn)
+	caClient1, _ := NewPseudonymsysCAClient(testGrpcClientConn)
 	caCertificate1, err := caClient1.GenerateCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA: %s", err.Error())
@@ -82,7 +82,7 @@ func TestPseudonymsys(t *testing.T) {
 	// c2 connects to the same server as c1, so what we're really testing here is
 	// using transferCredential to authenticate with the same organization and not
 	// transferring credentials to another organization
-	c2, err := NewPseudonymsysClient(testGrpcClientConn)
+	c2, _ := NewPseudonymsysClient(testGrpcClientConn)
 	nym2, err := c2.GenerateNym(userSecret, caCertificate1, "testRegKey2")
 	if err != nil {
 		t.Errorf(err.Error())

--- a/client/schnorr_test.go
+++ b/client/schnorr_test.go
@@ -23,17 +23,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/config"
-	"github.com/xlab-si/emmy/crypto/groups"
 	pb "github.com/xlab-si/emmy/protobuf"
 )
-
-func testSchnorr(n *big.Int, group *groups.SchnorrGroup, variant pb.SchemaVariant) error {
-	c, err := NewSchnorrClient(testGrpcClientConn, variant, group, n)
-	if err != nil {
-		return err
-	}
-	return c.Run()
-}
 
 func TestSchnorr(t *testing.T) {
 	group := config.LoadSchnorrGroup()

--- a/crypto/encryption/cs_paillier.go
+++ b/crypto/encryption/cs_paillier.go
@@ -69,7 +69,8 @@ type CSPaillierSecretKey struct {
 	K1                   int
 }
 
-// CSPaillierPubKey currently does not use auxilary parameters/primes - no additional n, p, q parameters
+// CSPaillierPubKey currently does not use auxiliary parameters/primes - no additional n, p,
+// q parameters
 // (as specified in a paper, original n, p, q can be used).
 type CSPaillierPubKey struct {
 	N  *big.Int
@@ -117,9 +118,7 @@ type CSPaillierVerifierEncData struct {
 }
 
 func NewCSPaillier(secParams *CSPaillierSecParams) *CSPaillier {
-	var cspaillier CSPaillier
-
-	cspaillier = CSPaillier{
+	cspaillier := CSPaillier{
 		SecParams: secParams,
 	}
 	cspaillier.generateKey()
@@ -154,27 +153,18 @@ func NewCSPaillierFromSecKey(path string) (*CSPaillier, error) {
 		K1:                   int(sKey.K1),
 	}
 
-	var cspaillier CSPaillier
-	cspaillier = CSPaillier{
+	return &CSPaillier{
 		SecretKey: &secKey,
-	}
-
-	pKey := &CSPaillierPubKey{
-		N: secKey.N,
-	}
-	cspaillier.PubKey = pKey // Abs is used also in decrypt where PubKey is called
-
-	return &cspaillier, nil
+		PubKey: &CSPaillierPubKey{ // Abs is used also in decrypt where PubKey is called
+			N: secKey.N,
+		},
+	}, nil
 }
 
 func NewCSPaillierFromPubKey(pubKey *CSPaillierPubKey) *CSPaillier {
-	var cspaillier CSPaillier
-
-	cspaillier = CSPaillier{
+	return &CSPaillier{
 		PubKey: pubKey,
 	}
-
-	return &cspaillier
 }
 
 func NewCSPaillierFromPubKeyFile(path string) (*CSPaillier, error) {
@@ -204,13 +194,9 @@ func NewCSPaillierFromPubKeyFile(path string) (*CSPaillier, error) {
 		K1:                   int(pKey.K1),
 	}
 
-	var cspaillier CSPaillier
-
-	cspaillier = CSPaillier{
+	return &CSPaillier{
 		PubKey: &pubKey,
-	}
-
-	return &cspaillier, nil
+	}, nil
 }
 
 func (cspaillier *CSPaillier) StoreSecKey(path string) error {
@@ -233,6 +219,7 @@ func (cspaillier *CSPaillier) StoreSecKey(path string) error {
 	if err != nil {
 		return err
 	}
+
 	err = storage.Store(data, path)
 	if err != nil {
 		return err
@@ -260,6 +247,7 @@ func (cspaillier *CSPaillier) StorePubKey(path string) error {
 	if err != nil {
 		return err
 	}
+
 	err = storage.Store(data, path)
 	if err != nil {
 		return err
@@ -688,6 +676,11 @@ type VerifiableEncGroup struct {
 
 func NewVerifiableEncGroup(n, orderOfZn, n1 *big.Int) (*VerifiableEncGroup, error) {
 	g1, err := common.GetGeneratorOfZnSubgroup(n, orderOfZn, n1)
+	if err != nil {
+		log.Fatal(err)
+		return nil, err
+	}
+
 	h1, err := common.GetGeneratorOfZnSubgroup(n, orderOfZn, n1)
 	if err != nil {
 		log.Fatal(err)

--- a/crypto/encryption/paillier.go
+++ b/crypto/encryption/paillier.go
@@ -39,9 +39,7 @@ type PaillierPubKey struct {
 }
 
 func NewPaillier(primeLength int) *Paillier {
-	var paillier Paillier
-
-	paillier = Paillier{
+	paillier := Paillier{
 		primeLength: primeLength,
 	}
 	paillier.generateKey()
@@ -50,13 +48,9 @@ func NewPaillier(primeLength int) *Paillier {
 }
 
 func NewPubPaillier(pubKey *PaillierPubKey) *Paillier {
-	var paillier Paillier
-
-	paillier = Paillier{
+	return &Paillier{
 		pubKey: pubKey,
 	}
-
-	return &paillier
 }
 
 func (paillier *Paillier) Encrypt(m *big.Int) (*big.Int, error) {

--- a/crypto/signatures/cl.go
+++ b/crypto/signatures/cl.go
@@ -207,10 +207,14 @@ func (cl *CL) GetPubKey() *CLPubKey {
 func (cl *CL) generateKey() (err error) {
 	// generate two primes of length 512
 	p, err := common.GetSafePrime(512)
+	if err != nil {
+		return err
+	}
 	q, err := common.GetSafePrime(512)
 	if err != nil {
 		return err
 	}
+
 	n := new(big.Int).Mul(p, q)
 	a_L, b, c := cl.getQuadraticResidues(n)
 	cl.p = p

--- a/crypto/zkp/primitives/dlogproofs/schnorr.go
+++ b/crypto/zkp/primitives/dlogproofs/schnorr.go
@@ -54,8 +54,7 @@ type SchnorrProver struct {
 }
 
 func NewSchnorrProver(group *groups.SchnorrGroup, protocolType protocoltypes.ProtocolType) *SchnorrProver {
-	var prover SchnorrProver
-	prover = SchnorrProver{
+	prover := SchnorrProver{
 		Group:        group,
 		protocolType: protocolType,
 	}

--- a/crypto/zkp/primitives/qrproofs/qnr.go
+++ b/crypto/zkp/primitives/qrproofs/qnr.go
@@ -54,7 +54,7 @@ func ProveQNR(y *big.Int, qr *groups.QRRSA) (bool, error) {
 		}
 
 		proved := verifier.Verify(typ)
-		if proved == false {
+		if !proved {
 			return false, nil
 		}
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -180,7 +180,7 @@ func (s *Server) receive(stream pb.ServerStream) (*pb.Message, error) {
 	if err == io.EOF {
 		return nil, err
 	} else if err != nil {
-		return nil, fmt.Errorf("an error ocurred: %v", err)
+		return nil, fmt.Errorf("an error occurred: %v", err)
 	}
 	s.logger.Infof("Received request of type %T from the stream", resp.Content)
 	s.logger.Debugf("%+v", resp)

--- a/server/session.go
+++ b/server/session.go
@@ -14,8 +14,6 @@ type sessionManager struct {
 	sessionKeyByteLen int
 }
 
-type sessionKey string
-
 func newSessionManager(n int) (*sessionManager, error) {
 	var err error
 	if n < MIN_SESSION_KEY_BYTE_LEN {


### PR DESCRIPTION
This PR implements several minor corrections that silence megacheck, misspell and gosimple linters, so that they no longer emit specific warnings. It fixes:
* all misspellings,
* removes all split declarations and immediate assignments afterwards,
* replaces unused variables (errors) in test code with `_`,
* adds error handling where it was missing.

Several improvements could still be made, as these changes don't cover all the warnings reported by the above mentioned linters, nor do we consider the output of other important linters (to be discussed in future).