### PR TITLE
Add version and copyright info to CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,11 @@ setup_linter:
 install:
 	go install
 
+# Install to produce emmy binary, but also add version information
+# Use with "make release version=x.y.z"
+release:
+	go install -ldflags "-X main.version=$(version)" emmy.go
+
 # Run test for all packages and report test coverage status
 test:
 	go test -v -cover $(ALL)

--- a/emmy.go
+++ b/emmy.go
@@ -19,16 +19,26 @@ package main
 
 import (
 	"os"
+	"time"
 
 	"github.com/urfave/cli"
 	emmy "github.com/xlab-si/emmy/cmd"
 )
 
+// version marks the version of emmy.
+// Its value should be set externally at compile time, by appending
+// -ldflags "-X main.version=x.y.z" option to go build/run/install commands at compile time.
+// In case its value remains empty, the CLI simply contains no version information.
+var version string
+
 // main runs the emmy CLI app.
 func main() {
 	app := cli.NewApp()
 	app.Name = "emmy"
-	app.Version = "0.1"
+	app.Copyright = `(c) 2017 XLAB d.o.o.
+		Licensed under Apache License, Version 2.0.`
+	app.Version = version
+	app.Compiled = time.Now()
 	app.Usage = `A CLI app for running emmy server, emmy clients 
 		and examples of proofs offered by the emmy library`
 	app.Commands = []cli.Command{emmy.ServerCmd, emmy.ClientCmd}

--- a/emmy.go
+++ b/emmy.go
@@ -19,7 +19,6 @@ package main
 
 import (
 	"os"
-	"time"
 
 	"github.com/urfave/cli"
 	emmy "github.com/xlab-si/emmy/cmd"
@@ -38,7 +37,6 @@ func main() {
 	app.Copyright = `(c) 2017 XLAB d.o.o.
 		Licensed under Apache License, Version 2.0.`
 	app.Version = version
-	app.Compiled = time.Now()
 	app.Usage = `A CLI app for running emmy server, emmy clients 
 		and examples of proofs offered by the emmy library`
 	app.Commands = []cli.Command{emmy.ServerCmd, emmy.ClientCmd}


### PR DESCRIPTION
This commit adds copyright and version information to the emmy CLI command. Version can be set with the new `release` target in the *Makefile*.

By running `make release version=0.0.1`, we get `emmy` binary, and running it shows us the following:
```bash
$ emmy
NAME:
   emmy - A CLI app for running emmy server, emmy clients 
    and examples of proofs offered by the emmy library

USAGE:
   emmy [global options] command [command options] [arguments...]

VERSION:
   0.0.1

COMMANDS:
     server   A server (verifier) that verifies clients (provers)
     client   A client (prover) that wants to prove something to the server (verifier)
     help, h  Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version

COPYRIGHT:
   (c) 2017 XLAB d.o.o.
    Licensed under Apache License, Version 2.0.
```
Or, to show just the version: 
 ````bash
$ emmy --version
emmy version 0.0.1
````

Note that running `make` (as opposed to `make release version=x.y.z`) will produce a binary with version unset. In this case, the `VERSION` section of the output above will not be displayed, so the behavior will be exactly the same as it was up until now. The same happens if you forget to specify the `version` argument to the `make release` command.