### PR TITLE
DamgardFujisaki commitment equality and square proof

### DIFF
--- a/crypto/commitments/damgard-fujisaki.go
+++ b/crypto/commitments/damgard-fujisaki.go
@@ -71,6 +71,7 @@ func NewDamgardFujisakiCommitter(n, h, g, t *big.Int, k int) *DamgardFujisakiCom
 		T: t}
 }
 
+// TODO: the naming is not OK because it also sets committer.committedValue and committer.r
 func (committer *DamgardFujisakiCommitter) GetCommitMsg(a *big.Int) (*big.Int, error) {
 	abs := new(big.Int).Abs(a)
 	if abs.Cmp(committer.T) != -1 {
@@ -83,6 +84,18 @@ func (committer *DamgardFujisakiCommitter) GetCommitMsg(a *big.Int) (*big.Int, e
 	r := common.GetRandomInt(boundary)
 	c := committer.ComputeCommit(a, r)
 
+	committer.committedValue = a
+	committer.r = r
+	return c, nil
+}
+
+func (committer *DamgardFujisakiCommitter) GetCommitMsgWithGivenR(a, r *big.Int) (*big.Int, error) {
+	abs := new(big.Int).Abs(a)
+	if abs.Cmp(committer.T) != -1 {
+		return nil, fmt.Errorf("committed value needs to be in (-T, T)")
+	}
+	// c = G^a * H^r % group.N
+	c := committer.ComputeCommit(a, r)
 	committer.committedValue = a
 	committer.r = r
 	return c, nil

--- a/crypto/commitments/damgard-fujisaki.go
+++ b/crypto/commitments/damgard-fujisaki.go
@@ -143,17 +143,17 @@ func NewDamgardFujisakiReceiver(safePrimeBitLength, k int) (*DamgardFujisakiRece
 		nil
 }
 
-// NewDamgardFujisakiReceiverFromExisting returns an instance of receiver with the same
-// parameters as the receiver used as an input. Different instances are needed because
+// NewDamgardFujisakiReceiverFromParams returns an instance of a receiver with the
+// parameters as given by input. Different instances are needed because
 // each sets its own Commitment value.
-func NewDamgardFujisakiReceiverFromParams(qrSpecialRSA *groups.QRSpecialRSA, H, G *big.Int,
-	K int) (
+func NewDamgardFujisakiReceiverFromParams(qrSpecialRSA *groups.QRSpecialRSA, h, g *big.Int,
+	k int) (
 	*DamgardFujisakiReceiver, error) {
 	return &DamgardFujisakiReceiver{damgardFujisaki: damgardFujisaki{
 		QRSpecialRSA: qrSpecialRSA,
-		H:            H,
-		G:            G,
-		K:            K},
+		H:            h,
+		G:            g,
+		K:            k},
 	}, nil
 }
 

--- a/crypto/commitments/damgard-fujisaki.go
+++ b/crypto/commitments/damgard-fujisaki.go
@@ -133,13 +133,14 @@ func NewDamgardFujisakiReceiver(safePrimeBitLength, k int) (*DamgardFujisakiRece
 // NewDamgardFujisakiReceiverFromExisting returns an instance of receiver with the same
 // parameters as the receiver used as an input. Different instances are needed because
 // each sets its own Commitment value.
-func NewDamgardFujisakiReceiverFromExisting(receiver *DamgardFujisakiReceiver) (
+func NewDamgardFujisakiReceiverFromParams(qrSpecialRSA *groups.QRSpecialRSA, H, G *big.Int,
+	K int) (
 	*DamgardFujisakiReceiver, error) {
 	return &DamgardFujisakiReceiver{damgardFujisaki: damgardFujisaki{
-		QRSpecialRSA: receiver.QRSpecialRSA,
-		H:            receiver.H,
-		G:            receiver.G,
-		K:            receiver.K},
+		QRSpecialRSA: qrSpecialRSA,
+		H:            H,
+		G:            G,
+		K:            K},
 	}, nil
 }
 

--- a/crypto/zkp/primitives/commitments/damgard-fujisaki_equality.go
+++ b/crypto/zkp/primitives/commitments/damgard-fujisaki_equality.go
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2017 XLAB d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package commitmentzkp
+
+import (
+	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/commitments"
+	"github.com/xlab-si/emmy/crypto/common"
+)
+
+type DFCommitmentEqualityProver struct {
+	committer1         *commitments.DamgardFujisakiCommitter
+	committer2         *commitments.DamgardFujisakiCommitter
+	challengeSpaceSize int
+	r1                 *big.Int
+	r21                *big.Int
+	r22                *big.Int
+}
+
+func NewDFCommitmentEqualityProver(committer1, committer2 *commitments.DamgardFujisakiCommitter,
+	challengeSpaceSize int) *DFCommitmentEqualityProver {
+	return &DFCommitmentEqualityProver{
+		committer1:         committer1,
+		committer2:         committer2,
+		challengeSpaceSize: challengeSpaceSize,
+	}
+}
+
+func (prover *DFCommitmentEqualityProver) GetProofRandomData() (*big.Int, *big.Int) {
+	// r1 from [0, T * 2^(NLength + ChallengeSpaceSize))
+	nLen := prover.committer1.QRSpecialRSA.N.BitLen()
+	exp := big.NewInt(int64(nLen + prover.challengeSpaceSize))
+	b := new(big.Int).Exp(big.NewInt(2), exp, nil)
+	b.Mul(b, prover.committer1.T)
+	r1 := common.GetRandomInt(b)
+	prover.r1 = r1
+
+	// r21 from [0, 2^(B + 2*NLength + ChallengeSpaceSize))
+	b = new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(
+		prover.committer1.B+2*nLen+prover.challengeSpaceSize)), nil)
+	r21 := common.GetRandomInt(b)
+	prover.r21 = r21
+
+	// r12 from [0, 2^(B + 2*NLength + ChallengeSpaceSize))
+	b = new(big.Int).Exp(big.NewInt(2), big.NewInt(int64(
+		prover.committer1.B+2*nLen+prover.challengeSpaceSize)), nil)
+	r22 := common.GetRandomInt(b)
+	prover.r22 = r22
+	// G^r1 * H^r12, G^r1 * H^r22
+	t1 := prover.committer1.ComputeCommit(r1, r21)
+	t2 := prover.committer2.ComputeCommit(r1, r22)
+	return t1, t2
+}
+
+func (prover *DFCommitmentEqualityProver) GetProofData(challenge *big.Int) (*big.Int,
+	*big.Int, *big.Int) {
+	// s1 = r1 + challenge*a (in Z, not modulo)
+	// s21 = r21 + challenge*rr1 (in Z, not modulo)
+	// s22 = r21 + challenge*rr2 (in Z, not modulo)
+	a, rr1 := prover.committer1.GetDecommitMsg()
+	_, rr2 := prover.committer2.GetDecommitMsg()
+	s1 := new(big.Int).Mul(challenge, a)
+	s1.Add(s1, prover.r1)
+	s21 := new(big.Int).Mul(challenge, rr1)
+	s21.Add(s21, prover.r21)
+	s22 := new(big.Int).Mul(challenge, rr2)
+	s22.Add(s22, prover.r22)
+	return s1, s21, s22
+}
+
+type DFCommitmentEqualityVerifier struct {
+	receiver1          *commitments.DamgardFujisakiReceiver
+	receiver2          *commitments.DamgardFujisakiReceiver
+	challengeSpaceSize int
+	challenge          *big.Int
+	proofRandomData1   *big.Int
+	proofRandomData2   *big.Int
+}
+
+func NewDFCommitmentEqualityVerifier(receiver1, receiver2 *commitments.DamgardFujisakiReceiver,
+	challengeSpaceSize int) *DFCommitmentEqualityVerifier {
+	return &DFCommitmentEqualityVerifier{
+		receiver1:          receiver1,
+		receiver2:          receiver2,
+		challengeSpaceSize: challengeSpaceSize,
+	}
+}
+
+func (verifier *DFCommitmentEqualityVerifier) SetProofRandomData(proofRandomData1,
+	proofRandomData2 *big.Int) {
+	verifier.proofRandomData1 = proofRandomData1
+	verifier.proofRandomData2 = proofRandomData2
+}
+
+func (verifier *DFCommitmentEqualityVerifier) GetChallenge() *big.Int {
+	exp := big.NewInt(int64(verifier.challengeSpaceSize))
+	b := new(big.Int).Exp(big.NewInt(2), exp, nil)
+	challenge := common.GetRandomInt(b)
+	verifier.challenge = challenge
+	return challenge
+}
+
+func (verifier *DFCommitmentEqualityVerifier) Verify(s1, s21, s22 *big.Int) bool {
+	// verify proofRandomData1 * verifier.receiver1.Commitment^challenge = G^s1 * H^s21 mod n1
+	// verify proofRandomData2 * verifier.receiver2.Commitment^challenge = G^s1 * H^s22 mod n2
+	left1 := verifier.receiver1.QRSpecialRSA.Exp(verifier.receiver1.Commitment, verifier.challenge)
+	left1 = verifier.receiver1.QRSpecialRSA.Mul(verifier.proofRandomData1, left1)
+	right1 := verifier.receiver1.ComputeCommit(s1, s21)
+
+	left2 := verifier.receiver2.QRSpecialRSA.Exp(verifier.receiver2.Commitment, verifier.challenge)
+	left2 = verifier.receiver2.QRSpecialRSA.Mul(verifier.proofRandomData2, left2)
+	right2 := verifier.receiver2.ComputeCommit(s1, s22)
+	return left1.Cmp(right1) == 0 && left2.Cmp(right2) == 0
+}

--- a/crypto/zkp/primitives/commitments/damgard-fujisaki_equality_test.go
+++ b/crypto/zkp/primitives/commitments/damgard-fujisaki_equality_test.go
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 XLAB d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package commitmentzkp
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xlab-si/emmy/crypto/commitments"
+	"github.com/xlab-si/emmy/crypto/common"
+)
+
+// TestProveDamgardFujisakiCommitmentEquality demonstrates how to prove that the two commitments c1, c2
+// hide the same number. Given c1, c2, prove that c1 = g1^x * h1^r1 (mod n1) and
+// c2 = g2^x * h2^r2 (mod n2) for some x, r1, r2 (note that both commitments hide x).
+func TestProveDamgardFujisakiCommitmentEquality(t *testing.T) {
+	receiver1, err := commitments.NewDamgardFujisakiReceiver(1024, 80)
+	if err != nil {
+		t.Errorf("Error in NewDamgardFujisakiReceiver: %v", err)
+	}
+
+	// n^2 is used for T - but any other value can be used as well
+	T := new(big.Int).Mul(receiver1.QRSpecialRSA.N, receiver1.QRSpecialRSA.N)
+	committer1 := commitments.NewDamgardFujisakiCommitter(receiver1.QRSpecialRSA.N,
+		receiver1.H, receiver1.G, T, receiver1.K)
+
+	receiver2, err := commitments.NewDamgardFujisakiReceiver(1024, 80)
+
+	committer2 := commitments.NewDamgardFujisakiCommitter(receiver2.QRSpecialRSA.N,
+		receiver2.H, receiver2.G, T, receiver2.K)
+
+	x := common.GetRandomInt(committer1.T)
+	c1, err := committer1.GetCommitMsg(x)
+	if err != nil {
+		t.Errorf("Error in computing commit msg: %v", err)
+	}
+	receiver1.SetCommitment(c1)
+
+	c2, err := committer2.GetCommitMsg(x)
+	if err != nil {
+		t.Errorf("Error in computing commit msg: %v", err)
+	}
+	receiver2.SetCommitment(c2)
+
+	challengeSpaceSize := 80
+	prover := NewDFCommitmentEqualityProver(committer1, committer2, challengeSpaceSize)
+	verifier := NewDFCommitmentEqualityVerifier(receiver1, receiver2, challengeSpaceSize)
+
+	proofRandomData1, proofRandomData2 := prover.GetProofRandomData()
+	verifier.SetProofRandomData(proofRandomData1, proofRandomData2)
+
+	challenge := verifier.GetChallenge()
+	s1, s21, s22 := prover.GetProofData(challenge)
+	proved := verifier.Verify(s1, s21, s22)
+
+	assert.Equal(t, true, proved, "DamgardFujisaki equality proof failed.")
+}

--- a/crypto/zkp/primitives/commitments/damgard-fujisaki_multiplication_test.go
+++ b/crypto/zkp/primitives/commitments/damgard-fujisaki_multiplication_test.go
@@ -40,14 +40,16 @@ func TestProveDamgardFujisakiCommitmentMultiplication(t *testing.T) {
 	committer1 := commitments.NewDamgardFujisakiCommitter(receiver1.QRSpecialRSA.N,
 		receiver1.H, receiver1.G, T, receiver1.K)
 
-	receiver2, err := commitments.NewDamgardFujisakiReceiverFromExisting(receiver1)
+	receiver2, err := commitments.NewDamgardFujisakiReceiverFromParams(receiver1.QRSpecialRSA,
+		receiver1.H, receiver1.G, receiver1.K)
 	if err != nil {
 		t.Errorf("Error in NewDamgardFujisakiReceiver: %v", err)
 	}
 	committer2 := commitments.NewDamgardFujisakiCommitter(receiver2.QRSpecialRSA.N,
 		receiver2.H, receiver2.G, T, receiver2.K)
 
-	receiver3, err := commitments.NewDamgardFujisakiReceiverFromExisting(receiver1)
+	receiver3, err := commitments.NewDamgardFujisakiReceiverFromParams(receiver1.QRSpecialRSA,
+		receiver1.H, receiver1.G, receiver1.K)
 	if err != nil {
 		t.Errorf("Error in NewDamgardFujisakiReceiver: %v", err)
 	}

--- a/crypto/zkp/primitives/commitments/damgard-fujisaki_square.go
+++ b/crypto/zkp/primitives/commitments/damgard-fujisaki_square.go
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2017 XLAB d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package commitmentzkp
+
+import (
+	"math/big"
+
+	"fmt"
+
+	"github.com/xlab-si/emmy/crypto/commitments"
+)
+
+type DFCommitmentSquareProver struct {
+	equalityProver *DFCommitmentEqualityProver
+}
+
+func NewDFCommitmentSquareProver(committer *commitments.DamgardFujisakiCommitter,
+	x *big.Int, challengeSpaceSize int) (*DFCommitmentSquareProver, *big.Int, error) {
+
+	// Input committer contains c = g^(x^2) * h^r (mod n).
+	// We now create two committers - committer1 will contain c1 = g^x * h^r1 (mod n),
+	// committer2 will contain the same c as committer, but using a different base c = c1^x * h^r2.
+	// Note that c = c1^x * h^r2 = g^(x^2) * h^(r1*x) * h^r2, so we choose r2 = r - r1*x.
+	// DFCommitmentSquareProver proves that committer1 and committer2 hide the same value (x) -
+	// using DFCommitmentEqualityProver.
+
+	committer1 := commitments.NewDamgardFujisakiCommitter(committer.QRSpecialRSA.N,
+		committer.H, committer.G, committer.T, committer.K)
+	c1, err := committer1.GetCommitMsg(x)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error when creating commit msg")
+	}
+
+	committer2 := commitments.NewDamgardFujisakiCommitter(committer.QRSpecialRSA.N,
+		committer.H, c1, committer.T, committer.K)
+	_, r := committer.GetDecommitMsg()
+	_, r1 := committer1.GetDecommitMsg()
+	r1x := new(big.Int).Mul(r1, x)
+	r2 := new(big.Int).Sub(r, r1x)
+
+	// we already know the commitment (it is c), so we ignore the first variable -
+	// just need to set the committer2 committedValue and r:
+	_, err = committer2.GetCommitMsgWithGivenR(x, r2)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error when creating commit msg with given r")
+	}
+
+	prover := NewDFCommitmentEqualityProver(committer1, committer2, challengeSpaceSize)
+
+	return &DFCommitmentSquareProver{
+		equalityProver: prover,
+	}, c1, nil
+}
+
+func (prover *DFCommitmentSquareProver) GetProofRandomData() (*big.Int, *big.Int) {
+	return prover.equalityProver.GetProofRandomData()
+}
+
+func (prover *DFCommitmentSquareProver) GetProofData(challenge *big.Int) (*big.Int,
+	*big.Int, *big.Int) {
+	return prover.equalityProver.GetProofData(challenge)
+}
+
+type DFCommitmentSquareVerifier struct {
+	equalityVerifier *DFCommitmentEqualityVerifier
+}
+
+func NewDFCommitmentSquareVerifier(receiver *commitments.DamgardFujisakiReceiver,
+	c1 *big.Int, challengeSpaceSize int) (*DFCommitmentSquareVerifier, error) {
+
+	receiver1, err := commitments.NewDamgardFujisakiReceiverFromParams(receiver.QRSpecialRSA,
+		receiver.H, receiver.G, receiver.K)
+	if err != nil {
+		return nil, fmt.Errorf("error when calling NewDamgardFujisakiReceiverFromParams")
+	}
+	receiver1.SetCommitment(c1)
+
+	receiver2, err := commitments.NewDamgardFujisakiReceiverFromParams(receiver.QRSpecialRSA,
+		receiver.H, c1, receiver.K)
+	if err != nil {
+		return nil, fmt.Errorf("error when calling NewDamgardFujisakiReceiverFromParams")
+	}
+	receiver2.SetCommitment(receiver.Commitment)
+
+	verifier := NewDFCommitmentEqualityVerifier(receiver1, receiver2, challengeSpaceSize)
+
+	return &DFCommitmentSquareVerifier{
+		equalityVerifier: verifier,
+	}, nil
+}
+
+func (verifier *DFCommitmentSquareVerifier) SetProofRandomData(proofRandomData1,
+	proofRandomData2 *big.Int) {
+	verifier.equalityVerifier.SetProofRandomData(proofRandomData1, proofRandomData2)
+}
+
+func (verifier *DFCommitmentSquareVerifier) GetChallenge() *big.Int {
+	return verifier.equalityVerifier.GetChallenge()
+}
+
+func (verifier *DFCommitmentSquareVerifier) Verify(s1, s21, s22 *big.Int) bool {
+	return verifier.equalityVerifier.Verify(s1, s21, s22)
+}

--- a/crypto/zkp/primitives/commitments/damgard-fujisaki_square.go
+++ b/crypto/zkp/primitives/commitments/damgard-fujisaki_square.go
@@ -25,8 +25,10 @@ import (
 	"github.com/xlab-si/emmy/crypto/commitments"
 )
 
+// DFCommitmentSquareProver proves that the commitment hides the square. Given c,
+// prove that c = g^(x^2) * h^r (mod n).
 type DFCommitmentSquareProver struct {
-	equalityProver *DFCommitmentEqualityProver
+	*DFCommitmentEqualityProver
 }
 
 func NewDFCommitmentSquareProver(committer *commitments.DamgardFujisakiCommitter,
@@ -63,21 +65,12 @@ func NewDFCommitmentSquareProver(committer *commitments.DamgardFujisakiCommitter
 	prover := NewDFCommitmentEqualityProver(committer1, committer2, challengeSpaceSize)
 
 	return &DFCommitmentSquareProver{
-		equalityProver: prover,
+		prover,
 	}, c1, nil
 }
 
-func (prover *DFCommitmentSquareProver) GetProofRandomData() (*big.Int, *big.Int) {
-	return prover.equalityProver.GetProofRandomData()
-}
-
-func (prover *DFCommitmentSquareProver) GetProofData(challenge *big.Int) (*big.Int,
-	*big.Int, *big.Int) {
-	return prover.equalityProver.GetProofData(challenge)
-}
-
 type DFCommitmentSquareVerifier struct {
-	equalityVerifier *DFCommitmentEqualityVerifier
+	*DFCommitmentEqualityVerifier
 }
 
 func NewDFCommitmentSquareVerifier(receiver *commitments.DamgardFujisakiReceiver,
@@ -100,19 +93,6 @@ func NewDFCommitmentSquareVerifier(receiver *commitments.DamgardFujisakiReceiver
 	verifier := NewDFCommitmentEqualityVerifier(receiver1, receiver2, challengeSpaceSize)
 
 	return &DFCommitmentSquareVerifier{
-		equalityVerifier: verifier,
+		verifier,
 	}, nil
-}
-
-func (verifier *DFCommitmentSquareVerifier) SetProofRandomData(proofRandomData1,
-	proofRandomData2 *big.Int) {
-	verifier.equalityVerifier.SetProofRandomData(proofRandomData1, proofRandomData2)
-}
-
-func (verifier *DFCommitmentSquareVerifier) GetChallenge() *big.Int {
-	return verifier.equalityVerifier.GetChallenge()
-}
-
-func (verifier *DFCommitmentSquareVerifier) Verify(s1, s21, s22 *big.Int) bool {
-	return verifier.equalityVerifier.Verify(s1, s21, s22)
 }

--- a/crypto/zkp/primitives/commitments/damgard-fujisaki_square_test.go
+++ b/crypto/zkp/primitives/commitments/damgard-fujisaki_square_test.go
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017 XLAB d.o.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package commitmentzkp
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xlab-si/emmy/crypto/commitments"
+	"github.com/xlab-si/emmy/crypto/common"
+)
+
+// TestProveDamgardFujisakiCommitmentSquare demonstrates how to prove that the commitment
+// hides the square. Given c, prove that c = g^(x^2) * h^r (mod n).
+func TestProveDamgardFujisakiCommitmentSquare(t *testing.T) {
+	receiver, err := commitments.NewDamgardFujisakiReceiver(1024, 80)
+	if err != nil {
+		t.Errorf("Error in NewDamgardFujisakiReceiver: %v", err)
+	}
+
+	// n^2 is used for T - but any other value can be used as well
+	T := new(big.Int).Mul(receiver.QRSpecialRSA.N, receiver.QRSpecialRSA.N)
+	committer := commitments.NewDamgardFujisakiCommitter(receiver.QRSpecialRSA.N,
+		receiver.H, receiver.G, T, receiver.K)
+
+	x := common.GetRandomInt(committer.QRSpecialRSA.N)
+	x2 := new(big.Int).Mul(x, x)
+	c, err := committer.GetCommitMsg(x2)
+	if err != nil {
+		t.Errorf("Error in computing commit msg: %v", err)
+	}
+	receiver.SetCommitment(c)
+
+	challengeSpaceSize := 80
+	prover, c1, err := NewDFCommitmentSquareProver(committer, x, challengeSpaceSize)
+	if err != nil {
+		t.Errorf("Error in instantiating DFCommitmentSquareProver: %v", err)
+	}
+
+	verifier, err := NewDFCommitmentSquareVerifier(receiver, c1, challengeSpaceSize)
+	if err != nil {
+		t.Errorf("Error in instantiating DFCommitmentSquareVerifier: %v", err)
+	}
+
+	proofRandomData1, proofRandomData2 := prover.GetProofRandomData()
+	verifier.SetProofRandomData(proofRandomData1, proofRandomData2)
+
+	challenge := verifier.GetChallenge()
+	s1, s21, s22 := prover.GetProofData(challenge)
+	proved := verifier.Verify(s1, s21, s22)
+
+	assert.Equal(t, true, proved, "DamgardFujisaki square proof failed.")
+}


### PR DESCRIPTION
DFCommitmentEqualityProof proves that the two commitments c1, c2 hide the same number. Given c1, c2, prove that c1 = g1^x * h1^r1 (mod n1) and c2 = g2^x * h2^r2 (mod n2) for some x, r1, r2 (note that both commitments hide x).

DFCommitmentSquareProof proves that the commitment hides the square. Given c, prove that c = g^(x^2) * h^r (mod n).