### PR TITLE
New structs for pseudonym system keys

### DIFF
--- a/client/compatibility/doc.go
+++ b/client/compatibility/doc.go
@@ -65,8 +65,8 @@
 //	Credential
 //	CredentialEC
 //	ECGroupElement
-//	OrgPubKeys
-//	OrgPubKeysEC
+//	PubKey
+//	PubKeyEC
 //	Transcript
 //	TranscriptEC
 // 	Pseudonym

--- a/client/compatibility/pseudonymsys.go
+++ b/client/compatibility/pseudonymsys.go
@@ -86,7 +86,7 @@ func NewOrgPubKeys(h1, h2 string) *OrgPubKeys {
 	}
 }
 
-// getNativeType translates compatibility OrgPubKeys to emmy's native pseudonymsys.OrgPubKeys.
+// getNativeType translates compatibility OrgPubKeys to emmy's native pseudonymsys.PubKey.
 func (k *OrgPubKeys) getNativeType() (*pseudonymsys.PubKey, error) {
 	h1, h1Ok := new(big.Int).SetString(k.H1, 10)
 	h2, h2Ok := new(big.Int).SetString(k.H2, 10)

--- a/client/compatibility/pseudonymsys.go
+++ b/client/compatibility/pseudonymsys.go
@@ -72,7 +72,7 @@ func (c *Credential) getNativeType() (*pseudonymsys.Credential, error) {
 	return cred, nil
 }
 
-// OrgPubKeys represents an equivalent of pseudonymsys.OrgPubKeys, but has string
+// OrgPubKeys represents an equivalent of pseudonymsys.PubKey, but has string
 // field types to overcome type restrictions of Go language binding tools.
 type OrgPubKeys struct {
 	H1 string
@@ -87,14 +87,14 @@ func NewOrgPubKeys(h1, h2 string) *OrgPubKeys {
 }
 
 // getNativeType translates compatibility OrgPubKeys to emmy's native pseudonymsys.OrgPubKeys.
-func (k *OrgPubKeys) getNativeType() (*pseudonymsys.OrgPubKeys, error) {
+func (k *OrgPubKeys) getNativeType() (*pseudonymsys.PubKey, error) {
 	h1, h1Ok := new(big.Int).SetString(k.H1, 10)
 	h2, h2Ok := new(big.Int).SetString(k.H2, 10)
 	if !h1Ok || !h2Ok {
 		return nil, fmt.Errorf("pubKeys.h1 or pubKeys.h2: %s", ArgsConversionError)
 	}
 
-	orgPubKeys := pseudonymsys.NewOrgPubKeys(h1, h2)
+	orgPubKeys := pseudonymsys.NewPubKey(h1, h2)
 	return orgPubKeys, nil
 }
 

--- a/client/compatibility/pseudonymsys.go
+++ b/client/compatibility/pseudonymsys.go
@@ -72,30 +72,29 @@ func (c *Credential) getNativeType() (*pseudonymsys.Credential, error) {
 	return cred, nil
 }
 
-// OrgPubKeys represents an equivalent of pseudonymsys.PubKey, but has string
+// PubKey represents an equivalent of pseudonymsys.PubKey, but has string
 // field types to overcome type restrictions of Go language binding tools.
-type OrgPubKeys struct {
+type PubKey struct {
 	H1 string
 	H2 string
 }
 
-func NewOrgPubKeys(h1, h2 string) *OrgPubKeys {
-	return &OrgPubKeys{
+func NewPubKey(h1, h2 string) *PubKey {
+	return &PubKey{
 		H1: h1,
 		H2: h2,
 	}
 }
 
-// getNativeType translates compatibility OrgPubKeys to emmy's native pseudonymsys.PubKey.
-func (k *OrgPubKeys) getNativeType() (*pseudonymsys.PubKey, error) {
+// getNativeType translates compatibility PubKey to emmy's native pseudonymsys.PubKey.
+func (k *PubKey) getNativeType() (*pseudonymsys.PubKey, error) {
 	h1, h1Ok := new(big.Int).SetString(k.H1, 10)
 	h2, h2Ok := new(big.Int).SetString(k.H2, 10)
 	if !h1Ok || !h2Ok {
-		return nil, fmt.Errorf("pubKeys.h1 or pubKeys.h2: %s", ArgsConversionError)
+		return nil, fmt.Errorf("pubKey.h1 or pubKey.h2: %s", ArgsConversionError)
 	}
 
-	orgPubKeys := pseudonymsys.NewPubKey(h1, h2)
-	return orgPubKeys, nil
+	return pseudonymsys.NewPubKey(h1, h2), nil
 }
 
 // Transcript represents an equivalent of dlogproofs.Transcript, but has string
@@ -187,7 +186,7 @@ func (c *PseudonymsysClient) GenerateNym(userSecret string,
 }
 
 func (c *PseudonymsysClient) ObtainCredential(userSecret string,
-	nym *Pseudonym, pubKeys *OrgPubKeys) (*Credential, error) {
+	nym *Pseudonym, publicKey *PubKey) (*Credential, error) {
 	// Translate secret
 	secret, secretOk := new(big.Int).SetString(userSecret, 10)
 	if !secretOk {
@@ -200,14 +199,14 @@ func (c *PseudonymsysClient) ObtainCredential(userSecret string,
 		return nil, err
 	}
 
-	// Translate OrgPubKeys
-	orgPubKeys, err := pubKeys.getNativeType()
+	// Translate PubKey
+	pubKey, err := publicKey.getNativeType()
 	if err != nil {
 		return nil, err
 	}
 
 	// Call PseudonymsysClient client with translated parameters
-	credential, err := c.PseudonymsysClient.ObtainCredential(secret, pseudonym, orgPubKeys)
+	credential, err := c.PseudonymsysClient.ObtainCredential(secret, pseudonym, pubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/client/compatibility/pseudonymsys_ec.go
+++ b/client/compatibility/pseudonymsys_ec.go
@@ -28,7 +28,7 @@ import (
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 )
 
-// OrgPubKeysEC represents an equivalent of pseudonymsys.OrgPubKeysEC,
+// OrgPubKeysEC represents an equivalent of pseudonymsys.PubKeyEC,
 // but has field types compatible with Go language binding tools.
 type OrgPubKeysEC struct {
 	H1 *ECGroupElement
@@ -43,7 +43,7 @@ func NewOrgPubKeysEC(h1, h2 *ECGroupElement) *OrgPubKeysEC {
 }
 
 // getNativeType translates compatibility OrgPubKeysEC to emmy's native pseudonymsys.OrgPubKeysEC.
-func (k *OrgPubKeysEC) getNativeType() (*pseudonymsys.OrgPubKeysEC, error) {
+func (k *OrgPubKeysEC) getNativeType() (*pseudonymsys.PubKeyEC, error) {
 	h1, err := k.H1.getNativeType()
 	if err != nil {
 		return nil, fmt.Errorf("pubKeys.H1: %s", err)
@@ -53,7 +53,7 @@ func (k *OrgPubKeysEC) getNativeType() (*pseudonymsys.OrgPubKeysEC, error) {
 		return nil, fmt.Errorf("pubKeys.H2: %s", err)
 	}
 
-	orgPubKeys := pseudonymsys.NewOrgPubKeysEC(h1, h2)
+	orgPubKeys := pseudonymsys.NewPubKeyEC(h1, h2)
 	return orgPubKeys, nil
 }
 

--- a/client/compatibility/pseudonymsys_ec.go
+++ b/client/compatibility/pseudonymsys_ec.go
@@ -28,33 +28,32 @@ import (
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 )
 
-// OrgPubKeysEC represents an equivalent of pseudonymsys.PubKeyEC,
+// PubKeyEC represents an equivalent of pseudonymsys.PubKeyEC,
 // but has field types compatible with Go language binding tools.
-type OrgPubKeysEC struct {
+type PubKeyEC struct {
 	H1 *ECGroupElement
 	H2 *ECGroupElement
 }
 
-func NewOrgPubKeysEC(h1, h2 *ECGroupElement) *OrgPubKeysEC {
-	return &OrgPubKeysEC{
+func NewPubKeyEC(h1, h2 *ECGroupElement) *PubKeyEC {
+	return &PubKeyEC{
 		H1: h1,
 		H2: h2,
 	}
 }
 
-// getNativeType translates compatibility OrgPubKeysEC to emmy's native pseudonymsys.PubKeyEC.
-func (k *OrgPubKeysEC) getNativeType() (*pseudonymsys.PubKeyEC, error) {
+// getNativeType translates compatibility PubKeyEC to emmy's native pseudonymsys.PubKeyEC.
+func (k *PubKeyEC) getNativeType() (*pseudonymsys.PubKeyEC, error) {
 	h1, err := k.H1.getNativeType()
 	if err != nil {
-		return nil, fmt.Errorf("pubKeys.H1: %s", err)
+		return nil, fmt.Errorf("pubKey.H1: %s", err)
 	}
 	h2, err := k.H2.getNativeType()
 	if err != nil {
-		return nil, fmt.Errorf("pubKeys.H2: %s", err)
+		return nil, fmt.Errorf("pubKey.H2: %s", err)
 	}
 
-	orgPubKeys := pseudonymsys.NewPubKeyEC(h1, h2)
-	return orgPubKeys, nil
+	return pseudonymsys.NewPubKeyEC(h1, h2), nil
 }
 
 // TranscriptEC represents an equivalent of dlogproofs.TranscriptEC, but has string
@@ -204,7 +203,7 @@ func (c *PseudonymsysClientEC) GenerateNym(userSecret string,
 }
 
 func (c *PseudonymsysClientEC) ObtainCredential(userSecret string,
-	nym *PseudonymEC, pubKeys *OrgPubKeysEC) (*CredentialEC, error) {
+	nym *PseudonymEC, publicKey *PubKeyEC) (*CredentialEC, error) {
 	// Translate secret
 	secret, secretOk := new(big.Int).SetString(userSecret, 10)
 	if !secretOk {
@@ -217,14 +216,14 @@ func (c *PseudonymsysClientEC) ObtainCredential(userSecret string,
 		return nil, err
 	}
 
-	// Translate OrgPubKeysEC
-	orgPubKeys, err := pubKeys.getNativeType()
+	// Translate PubKeyEC
+	pubKey, err := publicKey.getNativeType()
 	if err != nil {
 		return nil, err
 	}
 
 	// Call PseudonymsysClientEC client with translated parameters
-	credential, err := c.PseudonymsysClientEC.ObtainCredential(secret, pseudonym, orgPubKeys)
+	credential, err := c.PseudonymsysClientEC.ObtainCredential(secret, pseudonym, pubKey)
 	if err != nil {
 		return nil, err
 	}

--- a/client/compatibility/pseudonymsys_ec.go
+++ b/client/compatibility/pseudonymsys_ec.go
@@ -42,7 +42,7 @@ func NewOrgPubKeysEC(h1, h2 *ECGroupElement) *OrgPubKeysEC {
 	}
 }
 
-// getNativeType translates compatibility OrgPubKeysEC to emmy's native pseudonymsys.OrgPubKeysEC.
+// getNativeType translates compatibility OrgPubKeysEC to emmy's native pseudonymsys.PubKeyEC.
 func (k *OrgPubKeysEC) getNativeType() (*pseudonymsys.PubKeyEC, error) {
 	h1, err := k.H1.getNativeType()
 	if err != nil {

--- a/client/pseudonymsys.go
+++ b/client/pseudonymsys.go
@@ -129,7 +129,7 @@ func (c *PseudonymsysClient) GenerateNym(userSecret *big.Int,
 
 // ObtainCredential returns anonymous credential.
 func (c *PseudonymsysClient) ObtainCredential(userSecret *big.Int,
-	nym *pseudonymsys.Pseudonym, orgPubKeys *pseudonymsys.OrgPubKeys) (
+	nym *pseudonymsys.Pseudonym, orgPubKeys *pseudonymsys.PubKey) (
 	*pseudonymsys.Credential, error) {
 	if err := c.openStream(c.grpcClient, "ObtainCredential"); err != nil {
 		return nil, err

--- a/client/pseudonymsys_ec.go
+++ b/client/pseudonymsys_ec.go
@@ -139,7 +139,7 @@ func (c *PseudonymsysClientEC) GenerateNym(userSecret *big.Int,
 
 // ObtainCredential returns anonymous credential.
 func (c *PseudonymsysClientEC) ObtainCredential(userSecret *big.Int,
-	nym *pseudonymsys.PseudonymEC, orgPubKeys *pseudonymsys.OrgPubKeysEC) (
+	nym *pseudonymsys.PseudonymEC, orgPubKeys *pseudonymsys.PubKeyEC) (
 	*pseudonymsys.CredentialEC, error) {
 	if err := c.openStream(c.grpcClient, "ObtainCredential_EC"); err != nil {
 		return nil, err

--- a/client/pseudonymsys_ec_test.go
+++ b/client/pseudonymsys_ec_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/groups"
-	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 )
 
 func TestPseudonymsysEC(t *testing.T) {
@@ -63,10 +62,7 @@ func TestPseudonymsysEC(t *testing.T) {
 	assert.NotNil(t, err, "Should produce an error")
 
 	orgName := "org1"
-	h1X, h1Y, h2X, h2Y := config.LoadPseudonymsysOrgPubKeysEC(orgName)
-	h1 := groups.NewECGroupElement(h1X, h1Y)
-	h2 := groups.NewECGroupElement(h2X, h2Y)
-	orgPubKeys := pseudonymsys.NewOrgPubKeysEC(h1, h2)
+	orgPubKeys := config.LoadPseudonymsysOrgPubKeysEC(orgName)
 	credential, err := c1.ObtainCredential(userSecret, nym1, orgPubKeys)
 	if err != nil {
 		t.Errorf(err.Error())

--- a/client/pseudonymsys_test.go
+++ b/client/pseudonymsys_test.go
@@ -24,7 +24,6 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/config"
-	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	"github.com/xlab-si/emmy/server"
 )
 
@@ -38,7 +37,7 @@ func TestPseudonymsys(t *testing.T) {
 	}
 
 	// usually the endpoint is different from the one used for CA:
-  c1, err := NewPseudonymsysClient(testGrpcClientConn, group)
+	c1, err := NewPseudonymsysClient(testGrpcClientConn, group)
 	userSecret := c1.GenerateMasterKey()
 
 	masterNym := caClient.GenerateMasterNym(userSecret)
@@ -66,8 +65,7 @@ func TestPseudonymsys(t *testing.T) {
 	assert.NotNil(t, err, "Should produce an error")
 
 	orgName := "org1"
-	h1, h2 := config.LoadPseudonymsysOrgPubKeys(orgName)
-	orgPubKeys := pseudonymsys.NewOrgPubKeys(h1, h2)
+	orgPubKeys := config.LoadPseudonymsysOrgPubKeys(orgName)
 	credential, err := c1.ObtainCredential(userSecret, nym1, orgPubKeys)
 	if err != nil {
 		t.Errorf(err.Error())

--- a/config/config.go
+++ b/config/config.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/xlab-si/emmy/crypto/groups"
+	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 )
 
 // init loads the default config file
@@ -138,27 +139,30 @@ func LoadQRRSA() *groups.QRRSA {
 	return qr
 }
 
-func LoadPseudonymsysOrgSecrets(orgName, dlogType string) (*big.Int, *big.Int) {
+func LoadPseudonymsysOrgSecrets(orgName, dlogType string) *pseudonymsys.SecKey {
 	org := viper.GetStringMap(fmt.Sprintf("pseudonymsys.%s.%s", orgName, dlogType))
 	s1, _ := new(big.Int).SetString(org["s1"].(string), 10)
 	s2, _ := new(big.Int).SetString(org["s2"].(string), 10)
-	return s1, s2
+	return pseudonymsys.NewSecKey(s1, s2)
 }
 
-func LoadPseudonymsysOrgPubKeys(orgName string) (*big.Int, *big.Int) {
+func LoadPseudonymsysOrgPubKeys(orgName string) *pseudonymsys.PubKey {
 	org := viper.GetStringMap(fmt.Sprintf("pseudonymsys.%s.%s", orgName, "dlog"))
 	h1, _ := new(big.Int).SetString(org["h1"].(string), 10)
 	h2, _ := new(big.Int).SetString(org["h2"].(string), 10)
-	return h1, h2
+	return pseudonymsys.NewPubKey(h1, h2)
 }
 
-func LoadPseudonymsysOrgPubKeysEC(orgName string) (*big.Int, *big.Int, *big.Int, *big.Int) {
+func LoadPseudonymsysOrgPubKeysEC(orgName string) *pseudonymsys.PubKeyEC {
 	org := viper.GetStringMap(fmt.Sprintf("pseudonymsys.%s.%s", orgName, "ecdlog"))
 	h1X, _ := new(big.Int).SetString(org["h1x"].(string), 10)
 	h1Y, _ := new(big.Int).SetString(org["h1y"].(string), 10)
 	h2X, _ := new(big.Int).SetString(org["h2x"].(string), 10)
 	h2Y, _ := new(big.Int).SetString(org["h2y"].(string), 10)
-	return h1X, h1Y, h2X, h2Y
+	return pseudonymsys.NewPubKeyEC(
+		groups.NewECGroupElement(h1X, h1Y),
+		groups.NewECGroupElement(h2X, h2Y),
+	)
 }
 
 func LoadPseudonymsysCASecret() *big.Int {
@@ -167,11 +171,11 @@ func LoadPseudonymsysCASecret() *big.Int {
 	return s
 }
 
-func LoadPseudonymsysCAPubKey() (*big.Int, *big.Int) {
+func LoadPseudonymsysCAPubKey() *pseudonymsys.PubKey {
 	ca := viper.GetStringMap("pseudonymsys.ca")
 	x, _ := new(big.Int).SetString(ca["x"].(string), 10)
 	y, _ := new(big.Int).SetString(ca["y1"].(string), 10)
-	return x, y
+	return pseudonymsys.NewPubKey(x, y)
 }
 
 func LoadServiceInfo() (string, string, string) {

--- a/crypto/zkp/schemes/pseudonymsys/ca.go
+++ b/crypto/zkp/schemes/pseudonymsys/ca.go
@@ -52,9 +52,9 @@ func NewCACertificate(blindedA, blindedB, r, s *big.Int) *CACertificate {
 	}
 }
 
-func NewCA(group *groups.SchnorrGroup, d, x, y *big.Int) *CA {
+func NewCA(group *groups.SchnorrGroup, d *big.Int, caPubKey *PubKey) *CA {
 	c := groups.GetEllipticCurve(groups.P256)
-	pubKey := ecdsa.PublicKey{Curve: c, X: x, Y: y}
+	pubKey := ecdsa.PublicKey{Curve: c, X: caPubKey.H1, Y: caPubKey.H2}
 	privateKey := ecdsa.PrivateKey{PublicKey: pubKey, D: d}
 
 	schnorrVerifier := dlogproofs.NewSchnorrVerifier(group, protocoltypes.Sigma)

--- a/crypto/zkp/schemes/pseudonymsys/ca_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/ca_ec.go
@@ -53,9 +53,9 @@ func NewCACertificateEC(blindedA, blindedB *groups.ECGroupElement, r, s *big.Int
 	}
 }
 
-func NewCAEC(d, x, y *big.Int, curveType groups.ECurve) *CAEC {
+func NewCAEC(d *big.Int, caPubKey *PubKey, curveType groups.ECurve) *CAEC {
 	c := groups.GetEllipticCurve(curveType)
-	pubKey := ecdsa.PublicKey{Curve: c, X: x, Y: y}
+	pubKey := ecdsa.PublicKey{Curve: c, X: caPubKey.H1, Y: caPubKey.H2}
 	privateKey := ecdsa.PrivateKey{PublicKey: pubKey, D: d}
 
 	schnorrVerifier := dlogproofs.NewSchnorrECVerifier(curveType, protocoltypes.Sigma)

--- a/crypto/zkp/schemes/pseudonymsys/keygen.go
+++ b/crypto/zkp/schemes/pseudonymsys/keygen.go
@@ -24,27 +24,48 @@ import (
 	"github.com/xlab-si/emmy/crypto/groups"
 )
 
+type SecKey struct {
+	S1, S2 *big.Int
+}
+
+func NewSecKey(s1, s2 *big.Int) *SecKey {
+	return &SecKey{s1, s2}
+}
+
+type PubKey struct {
+	H1, H2 *big.Int
+}
+
+func NewPubKey(h1, h2 *big.Int) *PubKey {
+	return &PubKey{h1, h2}
+}
+
+type PubKeyEC struct {
+	H1, H2 *groups.ECGroupElement
+}
+
+func NewPubKeyEC(h1, h2 *groups.ECGroupElement) *PubKeyEC {
+	return &PubKeyEC{h1, h2}
+}
+
 // GenerateKeyPair takes a schnorr group and constructs a pair of secret and public key for
 // pseudonym system scheme.
-// TODO return (SecKey, PubKey) instead
-func GenerateKeyPair(group *groups.SchnorrGroup) (*big.Int, *big.Int, *big.Int, *big.Int) {
+func GenerateKeyPair(group *groups.SchnorrGroup) (*SecKey, *PubKey) {
 	s1 := common.GetRandomInt(group.Q)
 	s2 := common.GetRandomInt(group.Q)
 	h1 := group.Exp(group.G, s1)
 	h2 := group.Exp(group.G, s2)
 
-	return s1, s2, h1, h2
+	return NewSecKey(s1, s2), NewPubKey(h1, h2)
 }
 
 // GenerateECKeyPair takes EC group and constructs a public key for pseudonym system scheme in EC
 // arithmetic.
-// TODO return (SecKey, PubKeyEC) instead
-func GenerateECKeyPair(group *groups.ECGroup) (*big.Int, *big.Int, *groups.ECGroupElement,
-	*groups.ECGroupElement) {
+func GenerateECKeyPair(group *groups.ECGroup) (*SecKey, *PubKeyEC) {
 	s1 := common.GetRandomInt(group.Q)
 	s2 := common.GetRandomInt(group.Q)
 	h1 := group.ExpBaseG(s1)
 	h2 := group.ExpBaseG(s2)
 
-	return s1, s2, h1, h2
+	return NewSecKey(s1, s2), NewPubKeyEC(h1, h2)
 }

--- a/crypto/zkp/schemes/pseudonymsys/org_issue.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_issue.go
@@ -49,22 +49,9 @@ func NewCredential(aToGamma, bToGamma, AToGamma, BToGamma *big.Int,
 	return credential
 }
 
-type OrgPubKeys struct {
-	H1 *big.Int
-	H2 *big.Int
-}
-
-func NewOrgPubKeys(h1, h2 *big.Int) *OrgPubKeys {
-	return &OrgPubKeys{
-		H1: h1,
-		H2: h2,
-	}
-}
-
 type OrgCredentialIssuer struct {
-	Group *groups.SchnorrGroup
-	s1    *big.Int
-	s2    *big.Int
+	Group  *groups.SchnorrGroup
+	secKey *SecKey
 
 	// the following fields are needed for issuing a credential
 	SchnorrVerifier *dlogproofs.SchnorrVerifier
@@ -74,7 +61,7 @@ type OrgCredentialIssuer struct {
 	b               *big.Int
 }
 
-func NewOrgCredentialIssuer(group *groups.SchnorrGroup, s1, s2 *big.Int) *OrgCredentialIssuer {
+func NewOrgCredentialIssuer(group *groups.SchnorrGroup, secKey *SecKey) *OrgCredentialIssuer {
 	// g1 = a_tilde, t1 = b_tilde,
 	// g2 = a, t2 = b
 	schnorrVerifier := dlogproofs.NewSchnorrVerifier(group, protocoltypes.Sigma)
@@ -82,8 +69,7 @@ func NewOrgCredentialIssuer(group *groups.SchnorrGroup, s1, s2 *big.Int) *OrgCre
 	equalityProver2 := dlogproofs.NewDLogEqualityBTranscriptProver(group)
 	org := OrgCredentialIssuer{
 		Group:           group,
-		s1:              s1,
-		s2:              s2,
+		secKey:          secKey,
 		SchnorrVerifier: schnorrVerifier,
 		EqualityProver1: equalityProver1,
 		EqualityProver2: equalityProver2,
@@ -107,12 +93,12 @@ func (org *OrgCredentialIssuer) VerifyAuthentication(z *big.Int) (
 	*big.Int, *big.Int, *big.Int, *big.Int, *big.Int, *big.Int, error) {
 	verified := org.SchnorrVerifier.Verify(z, nil)
 	if verified {
-		A := org.Group.Exp(org.b, org.s2)
+		A := org.Group.Exp(org.b, org.secKey.S2)
 		aA := org.Group.Mul(org.a, A)
-		B := org.Group.Exp(aA, org.s1)
+		B := org.Group.Exp(aA, org.secKey.S1)
 
-		x11, x12 := org.EqualityProver1.GetProofRandomData(org.s2, org.Group.G, org.b)
-		x21, x22 := org.EqualityProver2.GetProofRandomData(org.s1, org.Group.G, aA)
+		x11, x12 := org.EqualityProver1.GetProofRandomData(org.secKey.S2, org.Group.G, org.b)
+		x21, x22 := org.EqualityProver2.GetProofRandomData(org.secKey.S1, org.Group.G, aA)
 
 		return x11, x12, x21, x22, A, B, nil
 	} else {

--- a/crypto/zkp/schemes/pseudonymsys/org_nym_gen.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_nym_gen.go
@@ -41,16 +41,14 @@ func NewPseudonym(a, b *big.Int) *Pseudonym {
 
 type OrgNymGen struct {
 	EqualityVerifier *dlogproofs.DLogEqualityVerifier
-	x                *big.Int
-	y                *big.Int
+	caPubKey         *PubKey
 }
 
-func NewOrgNymGen(group *groups.SchnorrGroup, x, y *big.Int) *OrgNymGen {
+func NewOrgNymGen(group *groups.SchnorrGroup, caPubKey *PubKey) *OrgNymGen {
 	verifier := dlogproofs.NewDLogEqualityVerifier(group)
 	org := OrgNymGen{
 		EqualityVerifier: verifier,
-		x:                x,
-		y:                y,
+		caPubKey:         caPubKey,
 	}
 	return &org
 }
@@ -58,7 +56,7 @@ func NewOrgNymGen(group *groups.SchnorrGroup, x, y *big.Int) *OrgNymGen {
 func (org *OrgNymGen) GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2,
 	r, s *big.Int) (*big.Int, error) {
 	c := groups.GetEllipticCurve(groups.P256)
-	pubKey := ecdsa.PublicKey{Curve: c, X: org.x, Y: org.y}
+	pubKey := ecdsa.PublicKey{Curve: c, X: org.caPubKey.H1, Y: org.caPubKey.H2}
 
 	hashed := common.HashIntoBytes(blindedA, blindedB)
 	verified := ecdsa.Verify(&pubKey, hashed, r, s)

--- a/crypto/zkp/schemes/pseudonymsys/org_nym_gen_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_nym_gen_ec.go
@@ -41,17 +41,15 @@ func NewPseudonymEC(a, b *groups.ECGroupElement) *PseudonymEC {
 
 type OrgNymGenEC struct {
 	EqualityVerifier *dlogproofs.ECDLogEqualityVerifier
-	x                *big.Int
-	y                *big.Int
+	caPubKey         *PubKey
 	curveType        groups.ECurve
 }
 
-func NewOrgNymGenEC(x, y *big.Int, curveType groups.ECurve) *OrgNymGenEC {
+func NewOrgNymGenEC(pubKey *PubKey, curveType groups.ECurve) *OrgNymGenEC {
 	verifier := dlogproofs.NewECDLogEqualityVerifier(curveType)
 	org := OrgNymGenEC{
 		EqualityVerifier: verifier,
-		x:                x,
-		y:                y,
+		caPubKey:         pubKey,
 		curveType:        curveType,
 	}
 	return &org
@@ -60,7 +58,7 @@ func NewOrgNymGenEC(x, y *big.Int, curveType groups.ECurve) *OrgNymGenEC {
 func (org *OrgNymGenEC) GetChallenge(nymA, blindedA, nymB, blindedB,
 	x1, x2 *groups.ECGroupElement, r, s *big.Int) (*big.Int, error) {
 	c := groups.GetEllipticCurve(org.curveType)
-	pubKey := ecdsa.PublicKey{Curve: c, X: org.x, Y: org.y}
+	pubKey := ecdsa.PublicKey{Curve: c, X: org.caPubKey.H1, Y: org.caPubKey.H2}
 
 	hashed := common.HashIntoBytes(blindedA.X, blindedA.Y, blindedB.X, blindedB.Y)
 	verified := ecdsa.Verify(&pubKey, hashed, r, s)

--- a/crypto/zkp/schemes/pseudonymsys/org_transfer.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_transfer.go
@@ -25,21 +25,19 @@ import (
 )
 
 type OrgCredentialVerifier struct {
-	Group *groups.SchnorrGroup
-	s1    *big.Int
-	s2    *big.Int
+	Group  *groups.SchnorrGroup
+	secKey *SecKey
 
 	EqualityVerifier *dlogproofs.DLogEqualityVerifier
 	a                *big.Int
 	b                *big.Int
 }
 
-func NewOrgCredentialVerifier(group *groups.SchnorrGroup, s1, s2 *big.Int) *OrgCredentialVerifier {
+func NewOrgCredentialVerifier(group *groups.SchnorrGroup, secKey *SecKey) *OrgCredentialVerifier {
 	equalityVerifier := dlogproofs.NewDLogEqualityVerifier(group)
 	org := OrgCredentialVerifier{
 		Group:            group,
-		s1:               s1,
-		s2:               s2,
+		secKey:           secKey,
 		EqualityVerifier: equalityVerifier,
 	}
 
@@ -56,7 +54,7 @@ func (org *OrgCredentialVerifier) GetAuthenticationChallenge(a, b, a1, b1, x1, x
 }
 
 func (org *OrgCredentialVerifier) VerifyAuthentication(z *big.Int,
-	credential *Credential, orgPubKeys *OrgPubKeys) bool {
+	credential *Credential, orgPubKeys *PubKey) bool {
 	verified := org.EqualityVerifier.Verify(z)
 	if !verified {
 		return false

--- a/crypto/zkp/schemes/pseudonymsys/org_transfer_ec.go
+++ b/crypto/zkp/schemes/pseudonymsys/org_transfer_ec.go
@@ -25,8 +25,7 @@ import (
 )
 
 type OrgCredentialVerifierEC struct {
-	s1 *big.Int
-	s2 *big.Int
+	secKey *SecKey
 
 	EqualityVerifier *dlogproofs.ECDLogEqualityVerifier
 	a                *groups.ECGroupElement
@@ -34,11 +33,10 @@ type OrgCredentialVerifierEC struct {
 	curveType        groups.ECurve
 }
 
-func NewOrgCredentialVerifierEC(s1, s2 *big.Int, curveType groups.ECurve) *OrgCredentialVerifierEC {
+func NewOrgCredentialVerifierEC(secKey *SecKey, curveType groups.ECurve) *OrgCredentialVerifierEC {
 	equalityVerifier := dlogproofs.NewECDLogEqualityVerifier(curveType)
 	org := OrgCredentialVerifierEC{
-		s1:               s1,
-		s2:               s2,
+		secKey:           secKey,
 		EqualityVerifier: equalityVerifier,
 		curveType:        curveType,
 	}
@@ -57,7 +55,7 @@ func (org *OrgCredentialVerifierEC) GetAuthenticationChallenge(a, b, a1, b1,
 }
 
 func (org *OrgCredentialVerifierEC) VerifyAuthentication(z *big.Int,
-	credential *CredentialEC, orgPubKeys *OrgPubKeysEC) bool {
+	credential *CredentialEC, orgPubKeys *PubKeyEC) bool {
 	verified := org.EqualityVerifier.Verify(z)
 	if !verified {
 		return false

--- a/server/pseudonymsys.go
+++ b/server/pseudonymsys.go
@@ -33,8 +33,8 @@ func (s *Server) GenerateNym(stream pb.PseudonymSystem_GenerateNymServer) error 
 	}
 
 	group := config.LoadSchnorrGroup()
-	caPubKeyX, caPubKeyY := config.LoadPseudonymsysCAPubKey()
-	org := pseudonymsys.NewOrgNymGen(group, caPubKeyX, caPubKeyY)
+	caPubKey := config.LoadPseudonymsysCAPubKey()
+	org := pseudonymsys.NewOrgNymGen(group, caPubKey)
 
 	proofRandData := req.GetPseudonymsysNymGenProofRandomData()
 	x1 := new(big.Int).SetBytes(proofRandData.X1)
@@ -109,8 +109,8 @@ func (s *Server) ObtainCredential(stream pb.PseudonymSystem_ObtainCredentialServ
 	}
 
 	group := config.LoadSchnorrGroup()
-	s1, s2 := config.LoadPseudonymsysOrgSecrets("org1", "dlog")
-	org := pseudonymsys.NewOrgCredentialIssuer(group, s1, s2)
+	secKey := config.LoadPseudonymsysOrgSecrets("org1", "dlog")
+	org := pseudonymsys.NewOrgCredentialIssuer(group, secKey)
 
 	sProofRandData := req.GetSchnorrProofRandomData()
 	x := new(big.Int).SetBytes(sProofRandData.X)
@@ -196,8 +196,8 @@ func (s *Server) TransferCredential(stream pb.PseudonymSystem_TransferCredential
 	}
 
 	group := config.LoadSchnorrGroup()
-	s1, s2 := config.LoadPseudonymsysOrgSecrets("org1", "dlog")
-	org := pseudonymsys.NewOrgCredentialVerifier(group, s1, s2)
+	secKey := config.LoadPseudonymsysOrgSecrets("org1", "dlog")
+	org := pseudonymsys.NewOrgCredentialVerifier(group, secKey)
 
 	data := req.GetPseudonymsysTransferCredentialData()
 	orgName := data.OrgName
@@ -249,8 +249,7 @@ func (s *Server) TransferCredential(stream pb.PseudonymSystem_TransferCredential
 	}
 
 	// PubKeys of the organization that issue a credential:
-	h1, h2 := config.LoadPseudonymsysOrgPubKeys(orgName)
-	orgPubKeys := pseudonymsys.NewOrgPubKeys(h1, h2)
+	orgPubKeys := config.LoadPseudonymsysOrgPubKeys(orgName)
 
 	proofData := req.GetBigint()
 	z := new(big.Int).SetBytes(proofData.X1)

--- a/server/pseudonymsys_ca.go
+++ b/server/pseudonymsys_ca.go
@@ -35,8 +35,8 @@ func (s *Server) GenerateCertificate(stream pb.PseudonymSystemCA_GenerateCertifi
 
 	group := config.LoadSchnorrGroup()
 	d := config.LoadPseudonymsysCASecret()
-	pubKeyX, pubKeyY := config.LoadPseudonymsysCAPubKey()
-	ca := pseudonymsys.NewCA(group, d, pubKeyX, pubKeyY)
+	pubKey := config.LoadPseudonymsysCAPubKey()
+	ca := pseudonymsys.NewCA(group, d, pubKey)
 
 	sProofRandData := req.GetSchnorrProofRandomData()
 	x := new(big.Int).SetBytes(sProofRandData.X)

--- a/server/pseudonymsys_ca_ec.go
+++ b/server/pseudonymsys_ca_ec.go
@@ -32,8 +32,8 @@ func (s *Server) GenerateCertificate_EC(stream pb.PseudonymSystemCA_GenerateCert
 	}
 
 	d := config.LoadPseudonymsysCASecret()
-	pubKeyX, pubKeyY := config.LoadPseudonymsysCAPubKey()
-	ca := pseudonymsys.NewCAEC(d, pubKeyX, pubKeyY, curve)
+	pubKey := config.LoadPseudonymsysCAPubKey()
+	ca := pseudonymsys.NewCAEC(d, pubKey, curve)
 
 	sProofRandData := req.GetSchnorrEcProofRandomData()
 	x := sProofRandData.X.GetNativeType()


### PR DESCRIPTION
This PR introduces three new structs: `PubKey`, `PubKeyEC` and `SecKey` that represent  public keys for both implementations of pseudonym system scheme, and their secret keys, which are of the same type
for both implementations. `PubKey` and `PubKeyEC` are not only a different naming for our previous `OrgPubKeys` and `OrgPubKeysEC` types (these were removed), but are more generic, since CA's also have their corresponding `PubKey`.

Several structs and functions from the `pseudonymsys` package previously accepted parameters in the form of: `s1, s2 *big.Int`, `h1, h2 *groups.ECGroupElement` or similar - this PR modifies such structs and functions so that they accept appropriate key struct types.

Packages `client,` `compatibility`, `server` and `config` were updated in light of these changes.

I believe these new structs make the code a bit easier to follow for the readers unfamiliar with cryptographic core of emmy, since you don't have to be know, for instance, that `s1,s2` or `x,y` represent parts of a secret key, because this PR makes it obvious by introducing appropriate struct types.

@zitnik please review the changes to `compatibility` package. I can modify names of wrapper types if you prefer.