### PR TITLE
Export Server's fields and structs

### DIFF
--- a/server/info.go
+++ b/server/info.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (s *Server) GetServiceInfo(ctx context.Context, message *pb.EmptyMsg) (*pb.ServiceInfo, error) {
-	s.logger.Info("Client requested service information")
+	s.Logger.Info("Client requested service information")
 
 	name, provider, description := config.LoadServiceInfo()
 	info := &pb.ServiceInfo{

--- a/server/pedersen.go
+++ b/server/pedersen.go
@@ -62,7 +62,7 @@ func (s *Server) Pedersen(group *groups.SchnorrGroup, stream pb.Protocol_RunServ
 	r := new(big.Int).SetBytes(pedersenDecommitment.R)
 	valid := pedersenReceiver.CheckDecommitment(r, val)
 
-	s.logger.Noticef("Commitment scheme success: **%v**", valid)
+	s.Logger.Noticef("Commitment scheme success: **%v**", valid)
 
 	resp = &pb.Message{
 		Content: &pb.Message_Status{&pb.Status{Success: valid}},

--- a/server/pedersen_ec.go
+++ b/server/pedersen_ec.go
@@ -46,7 +46,7 @@ func (s *Server) PedersenEC(curveType groups.ECurve, stream pb.Protocol_RunServe
 
 	el := req.GetEcGroupElement()
 	if el == nil {
-		s.logger.Critical("Got a nil EC group element")
+		s.Logger.Critical("Got a nil EC group element")
 		return err
 	}
 
@@ -67,7 +67,7 @@ func (s *Server) PedersenEC(curveType groups.ECurve, stream pb.Protocol_RunServe
 	r := new(big.Int).SetBytes(pedersenDecommitment.R)
 	valid := pedersenECReceiver.CheckDecommitment(r, val)
 
-	s.logger.Noticef("Commitment scheme success: **%v**", valid)
+	s.Logger.Noticef("Commitment scheme success: **%v**", valid)
 
 	resp = &pb.Message{
 		Content: &pb.Message_Status{&pb.Status{Success: valid}},

--- a/server/pseudonymsys.go
+++ b/server/pseudonymsys.go
@@ -46,12 +46,12 @@ func (s *Server) GenerateNym(stream pb.PseudonymSystem_GenerateNymServer) error 
 	signatureR := new(big.Int).SetBytes(proofRandData.R)
 	signatureS := new(big.Int).SetBytes(proofRandData.S)
 
-	regKeyOk, err := s.registrationManager.CheckRegistrationKey(proofRandData.RegKey)
+	regKeyOk, err := s.RegistrationManager.CheckRegistrationKey(proofRandData.RegKey)
 
 	var resp *pb.Message
 
 	if !regKeyOk || err != nil {
-		s.logger.Debugf("registration key %s ok=%t, error=%v",
+		s.Logger.Debugf("registration key %s ok=%t, error=%v",
 			proofRandData.RegKey, regKeyOk, err)
 		resp = &pb.Message{
 			ProtocolError: "registration key verification failed",
@@ -63,7 +63,7 @@ func (s *Server) GenerateNym(stream pb.PseudonymSystem_GenerateNymServer) error 
 	} else {
 		challenge, err := org.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2, signatureR, signatureS)
 		if err != nil {
-			s.logger.Debug(err)
+			s.Logger.Debug(err)
 			resp = &pb.Message{
 				ProtocolError: err.Error(),
 			}
@@ -140,7 +140,7 @@ func (s *Server) ObtainCredential(stream pb.PseudonymSystem_ObtainCredentialServ
 
 	x11, x12, x21, x22, A, B, err := org.VerifyAuthentication(z)
 	if err != nil {
-		s.logger.Debug(err)
+		s.Logger.Debug(err)
 		resp = &pb.Message{
 			ProtocolError: err.Error(),
 		}
@@ -262,7 +262,7 @@ func (s *Server) TransferCredential(stream pb.PseudonymSystem_TransferCredential
 	if verified {
 		sessionKey, err := s.generateSessionKey()
 		if err != nil {
-			s.logger.Debug(err)
+			s.Logger.Debug(err)
 			resp.ProtocolError = "failed to obtain session key"
 		} else {
 			resp.Content = &pb.Message_SessionKey{
@@ -272,7 +272,7 @@ func (s *Server) TransferCredential(stream pb.PseudonymSystem_TransferCredential
 			}
 		}
 	} else {
-		s.logger.Debug("User authentication failed")
+		s.Logger.Debug("User authentication failed")
 		resp.ProtocolError = "user authentication failed"
 	}
 

--- a/server/pseudonymsys_ca.go
+++ b/server/pseudonymsys_ca.go
@@ -77,7 +77,7 @@ func (s *Server) GenerateCertificate(stream pb.PseudonymSystemCA_GenerateCertifi
 			},
 		}
 	} else {
-		s.logger.Debug(err)
+		s.Logger.Debug(err)
 		resp = &pb.Message{
 			ProtocolError: err.Error(),
 		}

--- a/server/pseudonymsys_ca_ec.go
+++ b/server/pseudonymsys_ca_ec.go
@@ -74,7 +74,7 @@ func (s *Server) GenerateCertificate_EC(stream pb.PseudonymSystemCA_GenerateCert
 			},
 		}
 	} else {
-		s.logger.Debug(err)
+		s.Logger.Debug(err)
 		resp = &pb.Message{
 			ProtocolError: err.Error(),
 		}

--- a/server/pseudonymsys_ec.go
+++ b/server/pseudonymsys_ec.go
@@ -45,12 +45,12 @@ func (s *Server) GenerateNym_EC(stream pb.PseudonymSystem_GenerateNym_ECServer) 
 	signatureR := new(big.Int).SetBytes(proofRandData.R)
 	signatureS := new(big.Int).SetBytes(proofRandData.S)
 
-	regKeyOk, err := s.registrationManager.CheckRegistrationKey(proofRandData.RegKey)
+	regKeyOk, err := s.RegistrationManager.CheckRegistrationKey(proofRandData.RegKey)
 
 	var resp *pb.Message
 
 	if !regKeyOk || err != nil {
-		s.logger.Debugf("Registration key %s ok=%t, error=%v",
+		s.Logger.Debugf("Registration key %s ok=%t, error=%v",
 			proofRandData.RegKey, regKeyOk, err)
 		resp = &pb.Message{
 			ProtocolError: "registration key verification failed",
@@ -62,7 +62,7 @@ func (s *Server) GenerateNym_EC(stream pb.PseudonymSystem_GenerateNym_ECServer) 
 	} else {
 		challenge, err := org.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2, signatureR, signatureS)
 		if err != nil {
-			s.logger.Debug(err)
+			s.Logger.Debug(err)
 			resp = &pb.Message{
 				ProtocolError: err.Error(),
 			}
@@ -139,7 +139,7 @@ func (s *Server) ObtainCredential_EC(stream pb.PseudonymSystem_ObtainCredential_
 	x11, x12, x21, x22, A, B, err := org.VerifyAuthentication(z)
 
 	if err != nil {
-		s.logger.Debug(err)
+		s.Logger.Debug(err)
 		resp = &pb.Message{
 			ProtocolError: err.Error(),
 		}
@@ -262,7 +262,7 @@ func (s *Server) TransferCredential_EC(stream pb.PseudonymSystem_TransferCredent
 	if verified {
 		sessionKey, err := s.generateSessionKey()
 		if err != nil {
-			s.logger.Debug(err)
+			s.Logger.Debug(err)
 			resp.ProtocolError = "failed to obtain session key"
 		} else {
 			resp.Content = &pb.Message_SessionKey{
@@ -272,7 +272,7 @@ func (s *Server) TransferCredential_EC(stream pb.PseudonymSystem_TransferCredent
 			}
 		}
 	} else {
-		s.logger.Debug("User authentication failed")
+		s.Logger.Debug("User authentication failed")
 		resp.ProtocolError = "user authentication failed"
 	}
 

--- a/server/registration_manager.go
+++ b/server/registration_manager.go
@@ -23,11 +23,11 @@ import (
 	"github.com/go-redis/redis"
 )
 
-type registrationManager struct {
+type RegistrationManager struct {
 	*redis.Client
 }
 
-func NewRegistrationManager(address string) (*registrationManager, error) {
+func NewRegistrationManager(address string) (*RegistrationManager, error) {
 	redisClient := redis.NewClient(&redis.Options{
 		Addr: address,
 	})
@@ -35,13 +35,13 @@ func NewRegistrationManager(address string) (*registrationManager, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to connect to redis database (%s)", err)
 	}
-	return &registrationManager{redisClient}, nil
+	return &RegistrationManager{redisClient}, nil
 }
 
 // CheckRegistrationKey checks whether provided key is present in registration database and deletes it,
 // preventing another registration with the same key.
 // Returns true if key was present (registration allowed), false otherwise.
-func (rm *registrationManager) CheckRegistrationKey(key string) (bool, error) {
+func (rm *RegistrationManager) CheckRegistrationKey(key string) (bool, error) {
 	resp := rm.Del(key)
 
 	err := resp.Err()

--- a/server/session.go
+++ b/server/session.go
@@ -10,18 +10,18 @@ import (
 // This is to prevent possible mistakes security reasons.
 const MIN_SESSION_KEY_BYTE_LEN = 24
 
-type sessionManager struct {
+type SessionManager struct {
 	sessionKeyByteLen int
 }
 
-func newSessionManager(n int) (*sessionManager, error) {
+func newSessionManager(n int) (*SessionManager, error) {
 	var err error
 	if n < MIN_SESSION_KEY_BYTE_LEN {
 		err = fmt.Errorf("desired length of the session key (%d B) is too short, falling back to %d B",
 			n, MIN_SESSION_KEY_BYTE_LEN)
 		n = MIN_SESSION_KEY_BYTE_LEN
 	}
-	return &sessionManager{
+	return &SessionManager{
 		sessionKeyByteLen: n,
 	}, err
 }
@@ -29,7 +29,7 @@ func newSessionManager(n int) (*sessionManager, error) {
 // generateSessionKey produces a secure random n-byte session key and returns its
 // base64-encoded representation that is URL-safe.
 // It reports an error if n is less than MIN_SESSION_KEY_BYTE_LEN.
-func (m *sessionManager) generateSessionKey() (*string, error) {
+func (m *SessionManager) generateSessionKey() (*string, error) {
 	randBytes := make([]byte, m.sessionKeyByteLen)
 
 	// reads m.sessionKeyByteLen random bytes (e.g. len(randBytes)) to randBytes array


### PR DESCRIPTION
### Scope
This PR exports structs `SessionManager` and `RegistrationManager` defined in the `server` package. In addition, `Server`'s fields `grpcServer` and `logger` are now also exported. 

### Purpose
These changes will provide more flexibility, as they will allow (future) implementations of server-side RPC handlers for specific schemes to reside outside our current `server` package. This means possibility of better organization of server-side implementations, which is a pending task at this point.

Consider this case: we currently have all server-side RPC handlers implemented in the `server` package, and all these handlers are hooked to our `Server` struct. So, basically, our server supports all the services defined in our protobuffers specification at once.

 As discussed offline, we don't want this on the long run (at least not for reasons other than demonstration), as the purpose of emmy server in production is to support a single anonymous authentication scheme only. Our current code base does not allow this, at least not in a simple and easily manageable way. The simple changes implemented in this PR are one step closer towards achieving this kind of flexibility.