### PR TITLE
Remove ProtocolError message

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -153,9 +153,7 @@ func (c *genericClient) receive() (*pb.Message, error) {
 	} else if err != nil {
 		return nil, fmt.Errorf("[client %v] An error occurred: %v", c.id, err)
 	}
-	if resp.ProtocolError != "" {
-		return nil, fmt.Errorf(resp.ProtocolError)
-	}
+
 	logger.Infof("[client %v] Received response of type %T from the genericClient", c.id, resp.Content)
 	logger.Debugf("%+v", resp)
 

--- a/client/pseudonymsys.go
+++ b/client/pseudonymsys.go
@@ -304,14 +304,10 @@ func (c *PseudonymsysClient) TransferCredential(orgName string, userSecret *big.
 	if err != nil {
 		return nil, err
 	}
-	sessionKey := resp.GetSessionKey()
-	if sessionKey == nil {
-		return nil, fmt.Errorf(resp.GetProtocolError())
-	}
 
 	if err := c.genericClient.CloseSend(); err != nil {
 		return nil, err
 	}
 
-	return sessionKey, nil
+	return resp.GetSessionKey(), nil
 }

--- a/client/pseudonymsys_ec.go
+++ b/client/pseudonymsys_ec.go
@@ -330,14 +330,9 @@ func (c *PseudonymsysClientEC) TransferCredential(orgName string, userSecret *bi
 		return nil, err
 	}
 
-	sessionKey := resp.GetSessionKey()
-	if sessionKey == nil {
-		return nil, fmt.Errorf(resp.GetProtocolError())
-	}
-
 	if err := c.genericClient.CloseSend(); err != nil {
 		return nil, err
 	}
 
-	return sessionKey, nil
+	return resp.GetSessionKey(), nil
 }

--- a/proto/messages.proto
+++ b/proto/messages.proto
@@ -43,7 +43,6 @@ message Message {
 		SessionKey SessionKey = 30;
 	}
 	int32 clientId = 28;
-	string ProtocolError = 29;
 }
 
 message EmptyMsg {}

--- a/server/pseudonymsys.go
+++ b/server/pseudonymsys.go
@@ -24,6 +24,8 @@ import (
 	"github.com/xlab-si/emmy/crypto/zkp/primitives/dlogproofs"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *Server) GenerateNym(stream pb.PseudonymSystem_GenerateNymServer) error {
@@ -53,50 +55,42 @@ func (s *Server) GenerateNym(stream pb.PseudonymSystem_GenerateNymServer) error 
 	if !regKeyOk || err != nil {
 		s.Logger.Debugf("registration key %s ok=%t, error=%v",
 			proofRandData.RegKey, regKeyOk, err)
-		resp = &pb.Message{
-			ProtocolError: "registration key verification failed",
-		}
+		return status.Error(codes.NotFound, "registration key verification failed")
+	}
 
-		if err = s.send(resp, stream); err != nil {
-			return err
-		}
-	} else {
-		challenge, err := org.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2, signatureR, signatureS)
-		if err != nil {
-			s.Logger.Debug(err)
-			resp = &pb.Message{
-				ProtocolError: err.Error(),
-			}
-		} else {
-			resp = &pb.Message{
-				Content: &pb.Message_PedersenDecommitment{
-					&pb.PedersenDecommitment{
-						X: challenge.Bytes(),
-					},
-				},
-			}
-		}
+	challenge, err := org.GetChallenge(nymA, blindedA, nymB, blindedB, x1, x2, signatureR, signatureS)
+	if err != nil {
+		s.Logger.Debug(err)
+		return status.Error(codes.Internal, err.Error())
 
-		if err := s.send(resp, stream); err != nil {
-			return err
-		}
+	}
+	resp = &pb.Message{
+		Content: &pb.Message_PedersenDecommitment{
+			&pb.PedersenDecommitment{
+				X: challenge.Bytes(),
+			},
+		},
+	}
 
-		req, err = s.receive(stream)
-		if err != nil {
-			return err
-		}
+	if err := s.send(resp, stream); err != nil {
+		return err
+	}
 
-		proofData := req.GetSchnorrProofData() // SchnorrProofData is used in DLog equality proof as well
-		z := new(big.Int).SetBytes(proofData.Z)
-		valid := org.Verify(z)
+	req, err = s.receive(stream)
+	if err != nil {
+		return err
+	}
 
-		resp = &pb.Message{
-			Content: &pb.Message_Status{&pb.Status{Success: valid}},
-		}
+	proofData := req.GetSchnorrProofData() // SchnorrProofData is used in DLog equality proof as well
+	z := new(big.Int).SetBytes(proofData.Z)
+	valid := org.Verify(z)
 
-		if err = s.send(resp, stream); err != nil {
-			return err
-		}
+	resp = &pb.Message{
+		Content: &pb.Message_Status{&pb.Status{Success: valid}},
+	}
+
+	if err = s.send(resp, stream); err != nil {
+		return err
 	}
 
 	return nil
@@ -141,22 +135,19 @@ func (s *Server) ObtainCredential(stream pb.PseudonymSystem_ObtainCredentialServ
 	x11, x12, x21, x22, A, B, err := org.VerifyAuthentication(z)
 	if err != nil {
 		s.Logger.Debug(err)
-		resp = &pb.Message{
-			ProtocolError: err.Error(),
-		}
-	} else {
-		resp = &pb.Message{
-			Content: &pb.Message_PseudonymsysIssueProofRandomData{
-				&pb.PseudonymsysIssueProofRandomData{
-					X11: x11.Bytes(),
-					X12: x12.Bytes(),
-					X21: x21.Bytes(),
-					X22: x22.Bytes(),
-					A:   A.Bytes(),
-					B:   B.Bytes(),
-				},
+		return status.Error(codes.Internal, err.Error())
+	}
+	resp = &pb.Message{
+		Content: &pb.Message_PseudonymsysIssueProofRandomData{
+			&pb.PseudonymsysIssueProofRandomData{
+				X11: x11.Bytes(),
+				X12: x12.Bytes(),
+				X21: x21.Bytes(),
+				X22: x22.Bytes(),
+				A:   A.Bytes(),
+				B:   B.Bytes(),
 			},
-		}
+		},
 	}
 
 	if err := s.send(resp, stream); err != nil {
@@ -254,26 +245,23 @@ func (s *Server) TransferCredential(stream pb.PseudonymSystem_TransferCredential
 	proofData := req.GetBigint()
 	z := new(big.Int).SetBytes(proofData.X1)
 
-	verified := org.VerifyAuthentication(z, credential, orgPubKeys)
-
-	resp = &pb.Message{}
-	// If something went wrong (either user was not authenticated or secure session key could not
-	// be generated), then sessionKey will be nil and the message will contain ProtocolError.
-	if verified {
-		sessionKey, err := s.generateSessionKey()
-		if err != nil {
-			s.Logger.Debug(err)
-			resp.ProtocolError = "failed to obtain session key"
-		} else {
-			resp.Content = &pb.Message_SessionKey{
-				SessionKey: &pb.SessionKey{
-					Value: *sessionKey,
-				},
-			}
-		}
-	} else {
+	if verified := org.VerifyAuthentication(z, credential, orgPubKeys); !verified {
 		s.Logger.Debug("User authentication failed")
-		resp.ProtocolError = "user authentication failed"
+		return status.Error(codes.Unauthenticated, "user authentication failed")
+	}
+
+	sessionKey, err := s.generateSessionKey()
+	if err != nil {
+		s.Logger.Debug(err)
+		return status.Error(codes.Internal, "failed to obtain session key")
+	}
+
+	resp = &pb.Message{
+		Content: &pb.Message_SessionKey{
+			SessionKey: &pb.SessionKey{
+				Value: *sessionKey,
+			},
+		},
 	}
 
 	if err = s.send(resp, stream); err != nil {

--- a/server/pseudonymsys_ca_ec.go
+++ b/server/pseudonymsys_ca_ec.go
@@ -23,6 +23,8 @@ import (
 	"github.com/xlab-si/emmy/config"
 	"github.com/xlab-si/emmy/crypto/zkp/schemes/pseudonymsys"
 	pb "github.com/xlab-si/emmy/proto"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *Server) GenerateCertificate_EC(stream pb.PseudonymSystemCA_GenerateCertificate_ECServer) error {
@@ -62,22 +64,20 @@ func (s *Server) GenerateCertificate_EC(stream pb.PseudonymSystemCA_GenerateCert
 	z := new(big.Int).SetBytes(sProofData.Z)
 	cert, err := ca.Verify(z)
 
-	if err == nil {
-		resp = &pb.Message{
-			Content: &pb.Message_PseudonymsysCaCertificateEc{
-				&pb.PseudonymsysCACertificateEC{
-					BlindedA: pb.ToPbECGroupElement(cert.BlindedA),
-					BlindedB: pb.ToPbECGroupElement(cert.BlindedB),
-					R:        cert.R.Bytes(),
-					S:        cert.S.Bytes(),
-				},
-			},
-		}
-	} else {
+	if err != nil {
 		s.Logger.Debug(err)
-		resp = &pb.Message{
-			ProtocolError: err.Error(),
-		}
+		return status.Error(codes.Internal, err.Error())
+	}
+
+	resp = &pb.Message{
+		Content: &pb.Message_PseudonymsysCaCertificateEc{
+			&pb.PseudonymsysCACertificateEC{
+				BlindedA: pb.ToPbECGroupElement(cert.BlindedA),
+				BlindedB: pb.ToPbECGroupElement(cert.BlindedB),
+				R:        cert.R.Bytes(),
+				S:        cert.S.Bytes(),
+			},
+		},
 	}
 
 	if err = s.send(resp, stream); err != nil {

--- a/server/server.go
+++ b/server/server.go
@@ -162,11 +162,8 @@ func (s *Server) send(msg *pb.Message, stream pb.ServerStream) error {
 	if err := stream.Send(msg); err != nil {
 		return fmt.Errorf("error sending message: %v", err)
 	}
-	if msg.ProtocolError != "" {
-		s.Logger.Infof("Successfully sent response of type %T", msg.ProtocolError)
-	} else {
-		s.Logger.Infof("Successfully sent response of type %T", msg.Content)
-	}
+
+	s.Logger.Infof("Successfully sent response of type %T", msg.Content)
 	s.Logger.Debugf("%+v", msg)
 
 	return nil


### PR DESCRIPTION
This commit removes custom `ProtocolError` protobuffer message that was previously a part of our `Message` message type for reporting non-grpc related errors that can occur during the execution of interactive protocols.

Instead, when a protocol error happens, we simply return the error with `return status.Error(<code>, <messageA>)` from the RPC handler, which is a standard way of reporting RPC errors to clients. According to [grpc status package docs](https://godoc.org/google.golang.org/grpc/status), all RPC handlers should return an error created by this package.

 As a consequence, client's `send` and server's `receive` functions are simplified, because there's no need for additional logic that catches `ProtocolError`s, as they are now reported as normal `error`s. This change also affects pseudonym system communication logic, which is now also simplified in several places.