### PR TITLE
Move Lipmaa decomposition to df package

### DIFF
--- a/crypto/df/lipmaa_decompose.go
+++ b/crypto/df/lipmaa_decompose.go
@@ -15,11 +15,13 @@
  *
  */
 
-package common
+package df
 
 import (
 	"fmt"
 	"math/big"
+
+	"github.com/xlab-si/emmy/crypto/common"
 )
 
 // Common values used for comparisons and big integer arithmetic, defined here for convenience.
@@ -51,9 +53,9 @@ func (l *lagrange) Set(w0, w1, w2, w3 *big.Int) {
 	l[3].Set(w3)
 }
 
-// LipmaaDecomposition calls lipmaaDecompose and converts its result from a
+// lipmaaDecomposition calls lipmaaDecompose and converts its result from a
 // fixed-size 4-element array to a slice containing only non-zero roots.
-func LipmaaDecomposition(n *big.Int) ([]*big.Int, error) {
+func lipmaaDecomposition(n *big.Int) ([]*big.Int, error) {
 	roots, err := lipmaaDecompose(n)
 	if err != nil {
 		return nil, err
@@ -218,11 +220,11 @@ func findPrimeAndTwoRoots(n *big.Int) (*big.Int, *big.Int, *big.Int) {
 	// repeat the procedure until we're fairly confident that p really is a prime
 	for !p.ProbablyPrime(20) {
 		// choose random w1 <= sqrt(n)
-		w1 = GetRandomInt(w1Upper)
+		w1 = common.GetRandomInt(w1Upper)
 
 		// choose random w2 <= sqrt(n - w1²)
 		w2Upper.Sqrt(new(big.Int).Sub(n, new(big.Int).Mul(w1, w1)))
-		w2 = GetRandomInt(w2Upper)
+		w2 = common.GetRandomInt(w2Upper)
 
 		// we need to ensure that exactly one of w1, w2 is even
 		if w1.Bit(0) == w2.Bit(0) {

--- a/crypto/df/lipmaa_decompose_test.go
+++ b/crypto/df/lipmaa_decompose_test.go
@@ -15,18 +15,18 @@
  *
  */
 
-package common
+package df
 
 import (
 	"math/big"
 	"testing"
 
-	"github.com/magiconair/properties/assert"
+	"github.com/stretchr/testify/assert"
 )
 
-// TestLipmaaDecompositionNegativeInteger tests whether decomposition function returns an error
+// TestLipmaaDecompositionNeg tests whether decomposition function returns an error
 // when an invaid argument (negative integer) is provided.
-func TestLipmaaDecompositionNegativeInteger(t *testing.T) {
+func TestLipmaaDecompositionNeg(t *testing.T) {
 	integer := big.NewInt(-1)
 	_, err := lipmaaDecompose(integer)
 	if err == nil {
@@ -34,9 +34,9 @@ func TestLipmaaDecompositionNegativeInteger(t *testing.T) {
 	}
 }
 
-// TestLipmaaDecompositionWithSmallIntegers iteratively tests whether the roots of retrieved
+// TestLipmaaDecompositionSmall iteratively tests whether the roots of retrieved
 // decompositions sum up exactly to a given integer when they are squared.
-func TestLipmaaDecompositionWithSmallIntegers(t *testing.T) {
+func TestLipmaaDecompositionSmall(t *testing.T) {
 	var bigInt = new(big.Int)
 	for i := 0; i <= 10000; i++ {
 		bigInt.SetInt64(int64(i))
@@ -49,8 +49,8 @@ func TestLipmaaDecompositionWithSmallIntegers(t *testing.T) {
 	}
 }
 
-// TestLipmaaDecompositionWithBigInteger tests whether decomposition works for a large integer.
-func TestLipmaaDecompositionWithBigInteger(t *testing.T) {
+// TestLipmaaDecompositionLarge tests whether decomposition works for a large integer.
+func TestLipmaaDecompositionLarge(t *testing.T) {
 	bigInt, _ := new(big.Int).SetString("16714772973240639959372252262788596420406994288943442724185217359247384753656472309049760952976644136858333233015922583099687128195321947212684779063190875332970679291085543110146729439665070418750765330192961290161474133279960593149307037455272278582955789954847238104228800942225108143276152223829168166008095539967222363070565697796008563529948374781419181195126018918350805639881625937503224895840081959848677868603567824611344898153185576740445411565094067875133968946677861528581074542082733743513314354002186235230287355796577107626422168586230066573268163712626444511811717579062108697723640288393001520781671", 10)
 	roots, _ := lipmaaDecompose(bigInt)
 	if squareRootsAndSum(roots).Cmp(bigInt) != 0 {
@@ -74,7 +74,7 @@ func TestLipmaaDecomposition(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		res, _ := LipmaaDecomposition(test.n)
+		res, _ := lipmaaDecomposition(test.n)
 		assert.Equal(t, len(res), test.expectedLen, "filtering lagrangian does not work")
 	}
 }

--- a/crypto/df/positive_commitment.go
+++ b/crypto/df/positive_commitment.go
@@ -41,7 +41,7 @@ func NewPositiveProver(committer *Committer,
 	// c2 = g^(x2^2) * h^r2, c3 = g^(x3^2) * h^r3 and where r = r0 + r1 + r2 + r3.
 	// We then prove that c0, c1, c2, c3 contains squares and verifier checks that c = c0*c1*c2*c3.
 
-	roots, err := common.LipmaaDecomposition(x)
+	roots, err := lipmaaDecomposition(x)
 	if err != nil {
 		return nil, fmt.Errorf("error when doing Lipmaa decomposition")
 	}


### PR DESCRIPTION
This PR moves Lipmaa decomposition functionality from `common` package to `df` package, since this is the only place where it is used. It is now unexported. 

Some tests were renamed for consistency and brevity, and an import of assert package was fixed.
