### PR TITLE
Introduce isQR function in qr package

### DIFF
--- a/crypto/common/common.go
+++ b/crypto/common/common.go
@@ -19,7 +19,6 @@ package common
 
 import (
 	"crypto/sha512"
-	"fmt"
 	"math/big"
 )
 
@@ -69,29 +68,6 @@ func LCM(x, y *big.Int) *big.Int {
 	t := new(big.Int)
 	t.Div(n, d)
 	return t
-}
-
-// IsQuadraticResidue returns true if a is quadratic residue in Z_p and false otherwise.
-// It works only when p is prime.
-func IsQuadraticResidue(a *big.Int, p *big.Int) (bool, error) {
-	if !p.ProbablyPrime(20) {
-		err := fmt.Errorf("p is not a prime")
-		return false, err
-	}
-
-	// check whether a^((p-1)/2) is 1 or -1 (Euler's criterion)
-	p1 := new(big.Int).Sub(p, big.NewInt(1))
-	p1 = new(big.Int).Div(p1, big.NewInt(2))
-	cr := new(big.Int).Exp(a, p1, p)
-
-	if cr.Cmp(big.NewInt(1)) == 0 {
-		return true, nil
-	} else if cr.Cmp(new(big.Int).Sub(p, big.NewInt(1))) == 0 {
-		return false, nil
-	} else {
-		err := fmt.Errorf("it seems that p is not a prime")
-		return false, err
-	}
 }
 
 // Contains returns true if array contains a given element, otherwise false.

--- a/crypto/qr/qr.go
+++ b/crypto/qr/qr.go
@@ -117,3 +117,21 @@ func (v *Verifier) Verify(z *big.Int) bool {
 		return z2.Cmp(s) == 0
 	}
 }
+
+// isQR accepts integer a and prime p, and returns true if
+// a is quadratic residue in Z_p group, false otherwise.
+// If p is not a prime, error is returned.
+func isQR(a *big.Int, p *big.Int) (bool, error) {
+	if !p.ProbablyPrime(20) {
+		return false, fmt.Errorf("p is not a prime")
+	}
+
+	one := big.NewInt(1)
+
+	// check whether a^((p-1)/2) is 1 or -1 (Euler's criterion)
+	pMin1 := new(big.Int).Sub(p, one)
+	exp := new(big.Int).Div(pMin1, big.NewInt(2)) // exponent
+	cr := new(big.Int).Exp(a, exp, p)
+
+	return cr.Cmp(one) == 0, nil
+}

--- a/crypto/qr/qr_test.go
+++ b/crypto/qr/qr_test.go
@@ -1,0 +1,26 @@
+package qr
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsQRInvalid checks that IsQR returns an
+// error when p is not a prime.
+func TestIsQRInvalid(t *testing.T) {
+	_, err := isQR(big.NewInt(0), big.NewInt(10))
+	assert.Error(t, err)
+}
+
+func TestIsQR(t *testing.T) {
+	x := big.NewInt(2)
+	p := big.NewInt(11)
+
+	a := new(big.Int).Exp(x, big.NewInt(2), p)
+
+	isqr, err := isQR(a, p)
+	assert.NoError(t, err)
+	assert.True(t, isqr)
+}

--- a/crypto/qr/rsa.go
+++ b/crypto/qr/rsa.go
@@ -21,8 +21,6 @@ import (
 	"math/big"
 
 	"fmt"
-
-	"github.com/xlab-si/emmy/crypto/common"
 )
 
 // RSA presents QR_N - group of quadratic residues modulo N where N is a product
@@ -97,11 +95,11 @@ func (g *RSA) IsElementInGroup(a *big.Int) (bool, error) {
 
 	factors := []*big.Int{g.P, g.Q}
 	for _, p := range factors {
-		isQR, err := common.IsQuadraticResidue(a, p)
+		factorIsQR, err := isQR(a, p)
 		if err != nil {
 			return false, err
 		}
-		if !isQR {
+		if !factorIsQR {
 			return false, nil
 		}
 	}


### PR DESCRIPTION
This commit removes `IsQuadraticResidue` from `crypto/common` package. Its refactored version is now called `IsQR`, and resides in the `crypto/qr` package.

@miha-stopar Please check tests for the function.