### PR TITLE
Use interfaces to model DB dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
 
 script:
   - make test
+  - make test-integration
 
 after_script:
   - docker stop emmy-redis

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,10 @@ release:
 test:
 	go test -v -cover $(ALL)
 
+# Run integration tests with a real redis db instance
+test-integration:
+	go test -v -cover ./client -db
+
 # Lists and formats all go source files with goimports
 fmt:
 	# List of files with different formatting than goimports'

--- a/README.md
+++ b/README.md
@@ -208,7 +208,6 @@ $ go get github.com/xlab-si/emmy
 ```
 
 This should give you the `emmy` executable in your `$GOBIN`.
-To successfully run unit tests, a [redis](https://redis.io/) instance is required to listen on the address given in [defaults.yml](config/defaults.yml), with the default value of *localhost:6379*.
 You can run the unit tests to see if everything is working properly with:
 
 ```

--- a/client/pseudonymsys_ec_test.go
+++ b/client/pseudonymsys_ec_test.go
@@ -43,22 +43,17 @@ func TestPseudonymsysEC(t *testing.T) {
 		t.Errorf("Error when registering with CA: %s", err.Error())
 	}
 
-	err = insertTestRegistrationKeys()
-	if err != nil {
-		t.Errorf("Error getting registration key: %s", err.Error())
-	}
-
 	//nym generation should fail with invalid registration key
 	_, err = c1.GenerateNym(userSecret, caCertificate, "029uywfh9udni")
 	assert.NotNil(t, err, "Should produce an error")
 
-	nym1, err := c1.GenerateNym(userSecret, caCertificate, "testRegKey1")
+	nym1, err := c1.GenerateNym(userSecret, caCertificate, "testRegKey3")
 	if err != nil {
 		t.Errorf(err.Error())
 	}
 
 	//nym generation should fail the second time with the same registration key
-	_, err = c1.GenerateNym(userSecret, caCertificate, "testRegKey1")
+	_, err = c1.GenerateNym(userSecret, caCertificate, "testRegKey3")
 	assert.NotNil(t, err, "Should produce an error")
 
 	orgName := "org1"
@@ -80,7 +75,7 @@ func TestPseudonymsysEC(t *testing.T) {
 	// using transferCredential to authenticate with the same organization and not
 	// transferring credentials to another organization
 	c2, _ := NewPseudonymsysClientEC(testGrpcClientConn, curveType)
-	nym2, err := c2.GenerateNym(userSecret, caCertificate1, "testRegKey2")
+	nym2, err := c2.GenerateNym(userSecret, caCertificate1, "testRegKey4")
 	if err != nil {
 		t.Errorf(err.Error())
 	}

--- a/client/pseudonymsys_test.go
+++ b/client/pseudonymsys_test.go
@@ -20,11 +20,9 @@ package client
 import (
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/xlab-si/emmy/config"
-	"github.com/xlab-si/emmy/server"
 )
 
 // TestPseudonymsys requires a running server (it is started in communication_test.go).
@@ -44,11 +42,6 @@ func TestPseudonymsys(t *testing.T) {
 	caCertificate, err := caClient.GenerateCertificate(userSecret, masterNym)
 	if err != nil {
 		t.Errorf("Error when registering with CA")
-	}
-
-	err = insertTestRegistrationKeys()
-	if err != nil {
-		t.Errorf("Error getting registration key: %s", err.Error())
 	}
 
 	//nym generation should fail with invalid registration key
@@ -98,22 +91,4 @@ func TestPseudonymsys(t *testing.T) {
 	sessionKey2, err := c2.TransferCredential(orgName, wrongUserSecret, nym2, credential)
 	assert.Nil(t, sessionKey2, "Authentication should fail, and session key should be nil")
 	assert.NotNil(t, err, "Should produce an error")
-}
-
-func insertTestRegistrationKeys() error {
-	registrationManager, err := server.NewRegistrationManager(config.LoadRegistrationDBAddress())
-	if err != nil {
-		return err
-	}
-
-	testRegKeys := [...]string{"testRegKey1", "testRegKey2"}
-	for _, regKey := range testRegKeys {
-		err = registrationManager.Set(regKey, regKey, time.Minute).Err()
-
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
 }

--- a/docs/develop.md
+++ b/docs/develop.md
@@ -17,7 +17,10 @@ they can aid the development.
 * `make` or `make install` will compile all the packages and produce `emmy` binary with `server` 
 and 
 `client` CLI commands.
-* `make test` will compile and run tests for all the packages and report test coverage.
+* `make test` will compile and run unit & interation tests for all the packages and report test coverage. Note that
+mock implementations will be used where storage backend is needed.
+* `make test-integration` will compile and run integration tests for the `client` package against a real redis
+ instance (expected to be up and running on _localhost:6379_), and report test coverage.
 * `make fmt` will list the files whose formating does not conform to that of *goimports*, and fix 
 their formatting. See [Source code formatting](#source-code-formatting).
 * `make deps` will use `dep` to fetch all dependencies and place them in the `vendor` directory. See 


### PR DESCRIPTION
This PR introduces a couple of changes related to where and how data is accessed via a DB client.

Previously we had two different structs for handling registration keys and for handling receiver records (CL scheme), both wrapping `*redis.Client`.

In place of these two structs we now have two new interfaces, `RegistrationManager` with method `CheckRegistrationKey` and `ReceiverRecordManager` with methods `Store` and `Load`. The former is currently used in server-side handlers in both pseudonym system schemes, and will be integrated with the CL scheme in near future as well. The latter is specific for the server-side handler of the CL scheme, and is thus defined the `crypto/cl` package.

Both interfaces have two implementations: a redis client and a mock implementation. Mock implementations store the data in-memory, and are very convenient for tests - recall that so far, our tests required a running instance of redis database; this is not the case anymore, as mock implementations are now used by default.

If we want to test the `client` package against an actual redis database, we can run `go test -v ./client -db`, or invoke the new make target with `make test-integration`.

Due to rather tight-coupled code, changes in several packages were required. To abstract away the database client implementation, I introduced another change: I moved database access from `cl.Org`'s `IssueCred` and  `UpdateCred` methods to the corresponding server-side handlers in `server` package. Due to our current code organization, I had to add a new field `clRecordManager` to the `Server` struct, and consequently update the parameters for `Server`'s constructor. This is an ugly hack, but it won't be like that once the project is reorganized to reduce coupling.
