### PR TITLE
Make SessionManager an interface

### DIFF
--- a/server/pseudonymsys.go
+++ b/server/pseudonymsys.go
@@ -250,7 +250,7 @@ func (s *Server) TransferCredential(stream pb.PseudonymSystem_TransferCredential
 		return status.Error(codes.Unauthenticated, "user authentication failed")
 	}
 
-	sessionKey, err := s.generateSessionKey()
+	sessionKey, err := s.GenerateSessionKey()
 	if err != nil {
 		s.Logger.Debug(err)
 		return status.Error(codes.Internal, "failed to obtain session key")

--- a/server/pseudonymsys_ec.go
+++ b/server/pseudonymsys_ec.go
@@ -249,7 +249,7 @@ func (s *Server) TransferCredential_EC(stream pb.PseudonymSystem_TransferCredent
 		return status.Error(codes.Unauthenticated, "user authentication failed")
 	}
 
-	sessionKey, err := s.generateSessionKey()
+	sessionKey, err := s.GenerateSessionKey()
 	if err != nil {
 		s.Logger.Debug(err)
 		return status.Error(codes.Internal, "failed to obtain session key")

--- a/server/server.go
+++ b/server/server.go
@@ -55,7 +55,7 @@ var _ EmmyServer = (*Server)(nil)
 type Server struct {
 	GrpcServer *grpc.Server
 	Logger     log.Logger
-	*SessionManager
+	SessionManager
 	RegistrationManager
 	clRecordManager cl.ReceiverRecordManager
 }
@@ -76,7 +76,7 @@ func NewServer(certFile, keyFile string, regMgr RegistrationManager,
 
 	logger.Infof("Successfully read certificate [%s] and key [%s]", certFile, keyFile)
 
-	sessionManager, err := newSessionManager(config.LoadSessionKeyMinByteLen())
+	sessionManager, err := NewRandSessionKeyGen(config.LoadSessionKeyMinByteLen())
 	if err != nil {
 		logger.Warning(err)
 	}

--- a/server/session.go
+++ b/server/session.go
@@ -6,33 +6,49 @@ import (
 	"fmt"
 )
 
-// Minimal allowed length of the session key, in bytes
-// This is to prevent possible mistakes security reasons.
-const MIN_SESSION_KEY_BYTE_LEN = 24
-
-type SessionManager struct {
-	sessionKeyByteLen int
+// SessionManager generates a new session key.
+// It returns a string containing the generated session key
+// or an error in case session key could not be generated.
+type SessionManager interface {
+	GenerateSessionKey() (*string, error)
 }
 
-func newSessionManager(n int) (*SessionManager, error) {
+// MIN_SESSION_KEY_BYTE_LEN represents the minimal allowed length
+// of the session key in bytes, for security reasons.
+const MIN_SESSION_KEY_BYTE_LEN = 24
+
+// RandSessionKeyGen generates session keys of the desired byte
+// length from random bytes.
+type RandSessionKeyGen struct {
+	byteLen int
+}
+
+// NewRandSessionKeyGen creates a new RandSessionKeyGen instance.
+// The new instance will be configured to generate session keys
+// with exactly byteLen bytes. For security reasons, the function
+// checks the byteLen against the value of MIN_SESSION_KEY_BYTE_LEN.
+// If the provided byteLen is smaller than MIN_SESSION_KEY_BYTE_LEN,
+// an error is set and the returned RandSessionKeyGen is configured
+// to use MIN_SESSION_KEY_BYTE_LEN instead of the provided byteLen.
+func NewRandSessionKeyGen(byteLen int) (*RandSessionKeyGen, error) {
 	var err error
-	if n < MIN_SESSION_KEY_BYTE_LEN {
+	if byteLen < MIN_SESSION_KEY_BYTE_LEN {
 		err = fmt.Errorf("desired length of the session key (%d B) is too short, falling back to %d B",
-			n, MIN_SESSION_KEY_BYTE_LEN)
-		n = MIN_SESSION_KEY_BYTE_LEN
+			byteLen, MIN_SESSION_KEY_BYTE_LEN)
+		byteLen = MIN_SESSION_KEY_BYTE_LEN
 	}
-	return &SessionManager{
-		sessionKeyByteLen: n,
+	return &RandSessionKeyGen{
+		byteLen: byteLen,
 	}, err
 }
 
-// generateSessionKey produces a secure random n-byte session key and returns its
-// base64-encoded representation that is URL-safe.
-// It reports an error if n is less than MIN_SESSION_KEY_BYTE_LEN.
-func (m *SessionManager) generateSessionKey() (*string, error) {
-	randBytes := make([]byte, m.sessionKeyByteLen)
+// GenerateSessionKey produces a secure random session key and returns
+// its base64-encoded representation that is URL-safe.
+// It reports an error in case random byte sequence could not be generated.
+func (m *RandSessionKeyGen) GenerateSessionKey() (*string, error) {
+	randBytes := make([]byte, m.byteLen)
 
-	// reads m.sessionKeyByteLen random bytes (e.g. len(randBytes)) to randBytes array
+	// reads m.byteLen random bytes (e.g. len(randBytes)) to randBytes array
 	_, err := rand.Read(randBytes)
 
 	// an error may occur if the system's secure RNG doesn't function properly, in which case


### PR DESCRIPTION
This commit introduces `SessionManager` as an interface with a `GenerateSessionKey()` method.
Emmy server now contains a field that must implement this interface. This decoupling will support easier refactoring in the future, as we will be able to easily switch to a different implementation of session key generation.

Existing session key generation logic was moved to the interface method of the `RandSessionKeyGen` struct.