### PR TITLE
Tidy README.md and theory.md + use math notation in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,50 @@
-# emmy - Library for zero-knowledge proofs 
+# emmy - Library for zero-knowledge proofs
 
 <p align="center">
 	<img src="emmy_logo.png" width="160" />
 </p>
 
 Emmy is a library for building protocols/applications based on zero-knowledge proofs, for example anonymous credentials.
-Zero-knowledge proofs are **client-server protocols** (in crypto terms also *prover-verifier*, where the prover takes on 
+Zero-knowledge proofs are **client-server protocols** (in crypto terms also _prover-verifier_, where the prover takes on
 the role of the client, and the verifier takes on the role of the server) where the client proves a knowledge
 of a secret without actually revealing the secret.
-  
-Emmy also implements a communication layer supporting the execution of these protocols. 
-Communication between clients and the server is based on [Protobuffers](https://developers.google.com/protocol-buffers/) and [gRPC](http://www.grpc.io/). 
-Emmy server is capable of serving (verifying) thousands of clients (provers) concurrently. Currently, the communication 
+
+Emmy also implements a communication layer supporting the execution of these protocols.
+Communication between clients and the server is based on [Protobuffers](https://developers.google.com/protocol-buffers/) and [gRPC](http://www.grpc.io/).
+Emmy server is capable of serving (verifying) thousands of clients (provers) concurrently. Currently, the communication
 is implemented for the two anonymous credential schemes (see [Currently offered cryptographic schemes](#currently-offered-cryptograhpic-schemes)).
 
-In addition, emmy is built with **mobile clients** in mind, as it comes with *compatibility* 
-package providing client wrappers and types that can be used for generating language bindings for 
-Android or iOS mobile platforms. 
+In addition, emmy is built with **mobile clients** in mind, as it comes with _compatibility_
+package providing client wrappers and types that can be used for generating language bindings for
+Android or iOS mobile platforms.
 
-To get some more information about the theory behind zero knowledge proofs or developing 
-various parts of emmy library, please refer to additional documentation in the *docs* folder.
+To get some more information about the theory behind zero knowledge proofs or developing
+various parts of emmy library, please refer to additional documentation in the _docs_ folder.
 
 #### What does emmy stand for?
-Emmy library is named after a German mathematician [Emmy Noether](https://en.wikipedia.org/wiki/Emmy_Noether), recognised as one of the most important 20th century mathematicians. Emmy Noether's groundbreaking work in the field of abstract algebra earned her a nickname *the mother of modern algebra*. We named our library after her, since modern cryptography generally relies heavily on abstract algebraic structures and concepts.
+
+Emmy library is named after a German mathematician [Emmy Noether](https://en.wikipedia.org/wiki/Emmy_Noether), recognised as one of the most important 20th century mathematicians. Emmy Noether's groundbreaking work in the field of abstract algebra earned her a nickname _the mother of modern algebra_. We named our library after her, since modern cryptography generally relies heavily on abstract algebraic structures and concepts.
 
 <!-- toc -->
+
 - [Currently offered cryptographic primitives](#currently-offered-cryptographic-primitives)
 - [Currently offered cryptographic schemes](#currently-offered-cryptograhpic-schemes)
 - [Installation](#installation)
 - [emmy CLI tool](#using-the-emmy-cli-tool)
-  * [emmy server](#emmy-server)
-  * [emmy clients](#emmy-clients)
-  * [TLS support](#tls-support)
+  - [emmy server](#emmy-server)
+  - [emmy clients](#emmy-clients)
+  - [TLS support](#tls-support)
 - [Further documentation](#documentation)
 <!-- tocstop -->
 
 # emmy - anonymous credentials showcase
- 
+
 Let's say you would like to travel to some country which requires proof of vaccination for certain diseases.
 You go to the clinic named South Loop Clinic, you get vaccinated and receive a proof that you are vaccinated. In fact, South Loop Clinic issues an anonymous credential which contains a proof that you have been vaccinated for certain diseases.
 
 The credential would contain something like:
 
-```
+```yaml
 Name: Andrew
 Surname: McCain
 Age: 45
@@ -57,30 +59,30 @@ whether it is going on about the same credential (unless you reveal some unique 
 In fact, even when user connects two times using the same credential, the verifier cannot know that the same
 credential has been used (that the same user is connecting).
 
-Let's assume there is a smart phone app which offers a UI to the emmy protocols. 
+Let's assume there is a smart phone app which offers a UI to the emmy protocols.
 
 To obtain a credential, user first need to create a master secret key. An app runs:
 
-```
+```go
 masterSecret := pubKey.GenerateUserMasterSecret()
 ```
 
 Here, pubKey is the public key of a clinic (clinic instantiates an `Org` from `crypto/cl/org.go` and
 uses it for issuing a credential).
 
-The communication between user and clinic go for example over NFC - between user's phone and 
+The communication between user and clinic go for example over NFC - between user's phone and
 some clinic terminal.
 
 User obtains a credential structure from a clinic (see `client/cl_test.go`):
 
-```
+```go
 rc, err := client.GetCredentialStructure()
 ```
 
 Credential structure for `Org` is defined in `config/defaults.yml`.
 User then fills the credential using an app and starts a protocol to obtain a credential:
 
-```
+```go
 name, _ := rc.GetAttr("Name")
 name.UpdateValue("Andrew")
 
@@ -104,29 +106,29 @@ The clinic verifies the validity of attributes and issues a credential. The veri
 is manual - an authorized person needs to verify the attributes and trigger the issuance of a credential.
 User now possesses a credential on his phone.
 
-When user arrives to a foreign country and a proof of vaccination is needed, he opens an app 
+When user arrives to a foreign country and a proof of vaccination is needed, he opens an app
 which runs:
 
-```
+```go
 acceptableCreds, err := client.GetAcceptableCreds()
 ```
 
 The server returns a list of organizations whose credentials it accepts. Additionally, the attributes
 that need to be revealed are specified:
 
-```
+```go
 revealedAttrs := acceptableCreds["South Loop Clinic"]
 ```
 
 In our case this might be:
 
-```
+```go
 revealedAttrs = []string{"Vaccinated}
 ```
 
 Now, the user can prove he has been vaccinated:
 
-```
+```go
 _, err := client.ProveCredential(cm, cred, revealedAttrs)
 ```
 
@@ -136,119 +138,121 @@ Verifier learns nothing about the user except that he was vaccinated for a certa
 
 The library supports building complex cryptographic schemes. To enable this various layers are needed:
 
- * mathematical groups in which the operations take place
- * utilities for generating safe primes, group generators, for decomposing integers into squares (`crypto/common`)
- * commitments (to commit to a chosen value while keeping it hidden to others)
- * zero-knowledge proofs as building blocks for schemes (protocols which are used as subprotocols in schemes, see `crypto/zkp`)
- * communication layer to enable client-server interaction (for messages exchanged in protocols)
- 
+- mathematical groups in which the operations take place
+- utilities for generating safe primes, group generators, for decomposing integers into squares (`crypto/common`)
+- commitments (to commit to a chosen value while keeping it hidden to others)
+- zero-knowledge proofs as building blocks for schemes (protocols which are used as subprotocols in schemes, see `crypto/zkp`)
+- communication layer to enable client-server interaction (for messages exchanged in protocols)
+
 ## Groups
 
 The following groups are offered in appropriate subpackages of `crypto` package:
 
- * &#8484;<sub>n</sub>* (`zn.Group`) - group of all integers smaller than _n_ and coprime with _n_. In the special 
- case when _n_ is a prime, a specialized group `zn.GroupZp` may be used.
- * Schnorr group (`schnorr.Group`) - cyclic subgroup of &#8484;<sub>p</sub>; the order of Schnorr group is _q_ where _p = qr + 1_ for some _r_ (_p_, _q_ are primes); 
- the order of Schnorr group is smaller than of &#8484;<sub>p</sub> which means faster computations
- * RSA group (`rsa.Group`) - group of all integers smaller than _n_ and coprime with _n_, where _n_ is a product of two distinct large primes
- * QR RSA group (`qr.RSA`) - group of quadratic residues modulo _n_ where _n_ is a product of two primes
- * QR special RSA group (`qr.RSASpecial`) - group of quadratic residues modulo _n_ where _n_ is a product of two safe primes
- * Elliptic curve group (`ec.Group`) - wrapper around Go `elliptic.Curve`
- 
+- $\mathbb{Z}_n^*$ (`zn.Group`) - group of all integers smaller than $n$ and coprime with $n$. In the special
+  case when $n$ is a prime, a specialized group `zn.GroupZp` may be used.
+- Schnorr group (`schnorr.Group`) - cyclic subgroup of $\mathbb{Z}_p$; the order of Schnorr group is $q$ where $p = qr + 1$ for some $r$ ($p, q$ are primes);
+  the order of Schnorr group is smaller than of &#8484;<sub>p</sub> which means faster computations
+- RSA group (`rsa.Group`) - group of all integers smaller than $n$ and coprime with $n$, where $n$ is a product of two distinct large primes
+- QR RSA group (`qr.RSA`) - group of quadratic residues modulo $n$ where $n$ is a product of two primes
+- QR special RSA group (`qr.RSASpecial`) - group of quadratic residues modulo $n$ where $n$ is a product of two safe primes
+- Elliptic curve group (`ec.Group`) - wrapper around Go `elliptic.Curve`
+
 ## Commitments
 
 The following commitments are offered in appropriate subpackages of `crypto` package:
 
- * Pedersen - for commitments in Schnorr group (supported &#8484;<sub>p</sub> and EC groups, see packages `pedersen`
- and `ecpedersen`, respectively) 
- * Damgard-Fujisaki [12] - for commitments in QR special RSA group (see package `df`)
- * Q-One-Way based [9] (see package `qoneway`). Note that Damgard-Fujisaki commitments should be used instead.
- 
+- Pedersen - for commitments in Schnorr group (supported $\mathbb{Z}_p$ and EC groups, see packages `pedersen`
+  and `ecpedersen`, respectively)
+- Damgard-Fujisaki [12] - for commitments in QR special RSA group (see package `df`)
+- Q-One-Way based [9] (see package `qoneway`). Note that Damgard-Fujisaki commitments should be used instead.
+
 ## Zero-knowledge proofs
 
- * Schnorr proofs for proving the knowledge of dlog [5],
-dlog equality [7], dlog equality blinded transcript [4], and partial dlog knowledge [8]. All of these proofs
- work with both &#8484;<sub>p</sub> and EC groups (see packages `schnorr` and `ecschnorr`, respectively).
- * Proofs of knowledge of homomorphism preimage and knowledge of partial homomorphism preimage
+- Schnorr proofs for proving the knowledge of dlog [5],
+  dlog equality [7], dlog equality blinded transcript [4], and partial dlog knowledge [8]. All of these proofs
+  work with both $\mathbb{Z}_p$ and EC groups (see packages `schnorr` and `ecschnorr`, respectively).
+- Proofs of knowledge of homomorphism preimage and knowledge of partial homomorphism preimage
   (see package `preimage`). These are generalizations of Schnorr proof to general
-   groups and one-way homomorphisms.
- * Proof of knowledge of representation (generalized Schnorr for multiple bases) [10]
- * Damgard-Fujisaki proofs (package `df`) [12] - for proving that you can open a commitment, 
- that two commitments hide the same value, that a commitment contains a multiplication of two committed values, 
- that the committed value is positive, that the committed value is a square, commitment range based on Lipmaa [11]
- * QR special RSA representation proof (like Schnorr but in QR special RSA group, see `qr` package)
- * Quadratic residuosity and nonresiduosity (packages `qr` and `qnr`) [6]
- * Camenisch-Shoup verifiable encryption [1]
- 
+  groups and one-way homomorphisms.
+- Proof of knowledge of representation (generalized Schnorr for multiple bases) [10]
+- Damgard-Fujisaki proofs (package `df`) [12] - for proving that you can open a commitment,
+  that two commitments hide the same value, that a commitment contains a multiplication of two committed values,
+  that the committed value is positive, that the committed value is a square, commitment range based on Lipmaa [11]
+- QR special RSA representation proof (like Schnorr but in QR special RSA group, see `qr` package)
+- Quadratic residuosity and nonresiduosity (packages `qr` and `qnr`) [6]
+- Camenisch-Shoup verifiable encryption [1]
+
 ## Communication
 
-Client-server communication code (based on gRPC) which enables execution of protocols over the internet is in 
+Client-server communication code (based on gRPC) which enables execution of protocols over the internet is in
 `client` and `server` packages. The messages and services are defined in `proto` folder. Translations between
 gRPC and native emmy messages are in `proto/translations.go`.
 
 # Currently offered cryptographic schemes
 
 Currently two anonymous credentials schemes are offered:
- 
- * Pseudonym system [4] (see `crypto/zkp/schemes/pseudonymsys`) (offered in &#8484;<sub>p</sub> and EC groups)
- * Camenisch-Lysyanskaya anonymous credentials [2][15] (see `crypto/cl`) - work in progress
- 
+
+- Pseudonym system [4] (see `crypto/zkp/schemes/pseudonymsys`) (offered in &#8484;<sub>p</sub> and EC groups)
+- Camenisch-Lysyanskaya anonymous credentials [2][15] (see `crypto/cl`) - work in progress
+
 Pseudonym system [4] was the first anonymous credential scheme and was superseded by Camenisch-Lysyanskaya scheme [2].
 
 ## Camenisch-Lysyanskaya anonymous credentials
 
 What are anonymous credentials:
 
- * user gets a certificate which contains personal data (name, gender, nationality, age ... )
- * the same certificate can be used to connect to different services (even if the databases are joined service providers 
- cannot map/link the users)
- * when connecting to a service, user can choose which data to reveal - some services might require only the possession 
- of a certificate (e.g. certifying that user paid for something), others might require some subset of data contained in certificate
- 
-While anonymity is obviously a MUST in e-voting, it might gradually become more important in other scenarios as well: 
+- user gets a certificate which contains personal data (name, gender, nationality, age ... )
+- the same certificate can be used to connect to different services (even if the databases are joined service providers
+  cannot map/link the users)
+- when connecting to a service, user can choose which data to reveal - some services might require only the possession
+  of a certificate (e.g. certifying that user paid for something), others might require some subset of data contained in certificate
 
- * online subscriptions 
- * wearable healthcare (for example sending diabetes data to a research team)
- * vehicle communications - cars sending out data about traffic
- 
+While anonymity is obviously a MUST in e-voting, it might gradually become more important in other scenarios as well:
+
+- online subscriptions
+- wearable healthcare (for example sending diabetes data to a research team)
+- vehicle communications - cars sending out data about traffic
+
 ### CL scheme - brief overview how it works
 
-There are public parameters _Z_, _S_, _R1_, ... , _Rl_.
+There are public parameters $Z, S, R_1, \ldots , R_k$.
 
-Issuer (of a credential) computes _Q_ based on public parameters, user attributes and random _v_:
+Issuer (of a credential) computes $Q$ based on public parameters, user attributes ($a_1, \ldots, a_k$) and random $v$:
 
-```
-Q = (Z / (R1^attr1 * ... * Rl^attrl * S^v)
-```
+$$
+Q = \frac{Z}{R_1^{a_1} \times \ldots \times R_k^{a_k} \times S^v}
+$$
 
-Issuer then chooses random prime _e_ (which is as public key in RSA algorithm), computes _d_ such that:
+Issuer then chooses random prime $e$ (which is as public key in RSA algorithm), computes $d$ such that:
 
-```
-x^(e*d) = x (mod n)
-```
+$$
+x^{ed} \equiv x \pmod n
+$$
 
-Issuer then computes _A_ (as in RSA signature):
+Issuer then computes $A$ (as in RSA signature):
 
-```
+$$
 A = Q^d
-```
+$$
 
-The credential in the form of a triplet _(A, e, v)_ is then given to a user.
+The credential in the form of a triplet $(A, e, v)$ is then given to a user.
 
 The organization that checks the validation of a user's credential checks whether:
 
-```
-A^e = Q = (Z / (R1^attr1 * ... * Rl^attrl * S^v) 
-```
+$$
+A^e = Q = \frac{Z}{R_1^{a_1} \times \ldots \times R_k^{a_k} \times S^v}
+$$
 
 If only a subset of attributes are revealed, zero-knowledge proof is applied - on the right side of the equation only
 a subset of attributes is known, thus the user needs to prove the knowledge of attributes such that the equation holds.
 
 # Warning
+
 _All components of emmy cryptography library are a work in progress. At this point, the library can be used to build proof of concept implementations for research purposes and **should never be used in production**. Project's code organization and library APIs are **not stable** - they are expected to undergo major changes, and may be changed at any point._
- 
+
 # Installation
-To install emmy, run 
+
+To install emmy, run
 
 ```
 $ go get github.com/xlab-si/emmy
@@ -266,13 +270,13 @@ $ go test ./...
 Below we provide some isntructions for using the `emmy` CLI tool. You can type `emmy` in the terminal to get a list of available commands and subcommands, and to get additional help.
 
 Emmy CLI offers two commands:
-* `emmy server` (with a `start` subcommand, e.g. `emmy server start`) and
-* `emmy client` (with subcommand `info`).
-> **Note:** emmy client command is currently going through a major revision. Running clients for
-    demo interactive protocols (_pedersen_, _pedersen_ec_, _schnorr_, _schnorr_ec_ _cspaillier_) is
-     no longer supported. Instead, clients for running protocols comprising anonymous 
-     authentication schemes will be added soon.
 
+- `emmy server` (with a `start` subcommand, e.g. `emmy server start`) and
+- `emmy client` (with subcommand `info`).
+  > **Note:** emmy client command is currently going through a major revision. Running clients for
+      demo interactive protocols (_pedersen_, _pedersen_ec_, _schnorr_, _schnorr_ec_ _cspaillier_) is
+       no longer supported. Instead, clients for running protocols comprising anonymous
+       authentication schemes will be added soon.
 
 ## emmy server
 
@@ -283,38 +287,44 @@ $ emmy server              # prints available subcommands
 $ emmy server start --help # prints subcommand flags, their meaning and default values
 ```
 
-To start emmy server with the default options, run 
+To start emmy server with the default options, run
 
 ```bash
 $ emmy server start        # starts emmy server with default settings
 ```
 
 Alternatively, you can control emmy server's behavior with the following options (specified as command line flags):
-1. **Port**: flag *--port* (shorthand *-p*), defaults to 7007.
 
-    Emmy server will listen for client connections on this port. Example: 
-    ```bash
-    $ emmy server start --port 2323   # starts emmy server that listens on port 2323
-    $ emmy server start -p 2323       # equivalently
-    ```
-2. **Logging level**: flag *--loglevel* (shorthand *-l*), which must be one of `debug|info|notice|error|critical`. Defaults to `ìnfo`.
+1. **Port**: flag _--port_ (shorthand _-p_), defaults to 7007.
 
-    For development or debugging purposes, we might prefer more fine-grained logs, in which case we would run:
-    ```bash
-    $ emmy server start --loglevel debug # or shorthand '-l debug'
-    ```
-3. **Log file**: flag *--logfile*, whose value is a path to the file where emmy server will output logs in addition to standard output. If the file does not exist, one is created. If it exists, logs will be appended to the file. It defaults to empty string, meaning that the server will not write output to any file.
+   Emmy server will listen for client connections on this port. Example:
 
-    Example:
-    ```bash
-    $ emmy server start --loglevel debug --logfile ~/emmy-server.log
-    ```
+   ```bash
+   $ emmy server start --port 2323   # starts emmy server that listens on port 2323
+   $ emmy server start -p 2323       # equivalently
+   ```
 
-4. **Certificate and private key**: flags *--cert* and *--key*, whose value is a path to a valid certificate and private key in PEM format. These will be used to secure communication channel with clients. Please refer to [explanation of TLS support in emmy](#tls-support) for explanation.
+2. **Logging level**: flag _--loglevel_ (shorthand _-l_), which must be one of `debug|info|notice|error|critical`. Defaults to `ìnfo`.
 
-5. **Address of the redis database**: flag *--db* of the form *redisHost:redisPort*, which points
- to a running instance of redis database that holds [registration keys](#registration-keys). 
- Defaults to *localhost:6379*.
+   For development or debugging purposes, we might prefer more fine-grained logs, in which case we would run:
+
+   ```bash
+   $ emmy server start --loglevel debug # or shorthand '-l debug'
+   ```
+
+3. **Log file**: flag _--logfile_, whose value is a path to the file where emmy server will output logs in addition to standard output. If the file does not exist, one is created. If it exists, logs will be appended to the file. It defaults to empty string, meaning that the server will not write output to any file.
+
+   Example:
+
+   ```bash
+   $ emmy server start --loglevel debug --logfile ~/emmy-server.log
+   ```
+
+4. **Certificate and private key**: flags _--cert_ and _--key_, whose value is a path to a valid certificate and private key in PEM format. These will be used to secure communication channel with clients. Please refer to [explanation of TLS support in emmy](#tls-support) for explanation.
+
+5. **Address of the redis database**: flag _--db_ of the form _redisHost:redisPort_, which points
+   to a running instance of redis database that holds [registration keys](#registration-keys).
+   Defaults to _localhost:6379_.
 
 Starting the server should produce an output similar to the one below:
 
@@ -328,7 +338,7 @@ Starting the server should produce an output similar to the one below:
 
 Line 1 indicates that the emmy server is being instantiated. Line 2 informs us about the server's certificate and private key paths to be used for secure communication with clients. Line 3 indicates that gRPC service for execution of crypto protocols is ready, and Line 4 tells us that gRPC tracing (used to oversee RPC calls) has been enabled. Finaly, line 5 indicates that emmy server is ready to serve clients.
 
-When a client establishes a connection to emmy server and starts communicating with it, the server will log additional information. How much gets logged depends on the desired log level. 
+When a client establishes a connection to emmy server and starts communicating with it, the server will log additional information. How much gets logged depends on the desired log level.
 
 You can stop emmy server by hitting `Ctrl+C` in the same terminal window.
 
@@ -336,67 +346,70 @@ You can stop emmy server by hitting `Ctrl+C` in the same terminal window.
 
 Emmy server verifies registration keys provided by clients when initiating the nym generation procedure. A separate server is expected to provide registration keys to clients via another channel (e.g. QR codes on physical person identification) and save the generated keys to a registration database, read by the emmy server.
 
-
 ## emmy clients (DEPRECATED)
 
-Running a client requires an instance of emmy server. First, spin up emmy server according to instructions in the previous section. You can then start one or more emmy clients in another terminal. 
+Running a client requires an instance of emmy server. First, spin up emmy server according to instructions in the previous section. You can then start one or more emmy clients in another terminal.
 
 We use commands of the following form to start emmy clients:
 
 ```bash
-$ emmy client <commonClientFlags> protocolSubcommand <protocolFlags> 
+$ emmy client <commonClientFlags> protocolSubcommand <protocolFlags>
 ```
 
-where *commonClientFlags* control the following aspects:
+where _commonClientFlags_ control the following aspects:
 
-1. **How many clients to start**: flag *--nclients* (shorthand *-n*), defaults to 1.
-2. **Whether to run clients concurrently or not**: flag *--concurrent*. Include this flag if you want to run the specified number of clients consurrently. The absence of this flag means that clients will be run sequentially.
-3. **Logging level**: flag *--loglevel* (shorthand *-l*), which must be one of `debug|info|notice|error|critical`. Defaults to `ìnfo`.
-4. **URI of the emmy server**: flag *--server*, defaults to *localhost:7007*.
-5. **CA certificate**: flag *--cacert*, points to a path to a certificate of the CA that issued emmy server's certificate, in PEM format. This will be used to secure communication channel with the server. Please refer to [explanation of TLS support in emmy](#tls-support) for explanation.
-6. **Server name override**: flag *--servername*. This will instruct clients to check server 
-certificate's common name (CN) against the value of the provided flag, instead of server's 
-hostname. Allows certificate validation to pass even when server's hostname does not 
-match the CN specified in server's certificate. 
+1.  **How many clients to start**: flag _--nclients_ (shorthand _-n_), defaults to 1.
+2.  **Whether to run clients concurrently or not**: flag _--concurrent_. Include this flag if you want to run the specified number of clients consurrently. The absence of this flag means that clients will be run sequentially.
+3.  **Logging level**: flag _--loglevel_ (shorthand _-l_), which must be one of `debug|info|notice|error|critical`. Defaults to `ìnfo`.
+4.  **URI of the emmy server**: flag _--server_, defaults to _localhost:7007_.
+5.  **CA certificate**: flag _--cacert_, points to a path to a certificate of the CA that issued emmy server's certificate, in PEM format. This will be used to secure communication channel with the server. Please refer to [explanation of TLS support in emmy](#tls-support) for explanation.
+6.  **Server name override**: flag _--servername_. This will instruct clients to check server
+    certificate's common name (CN) against the value of the provided flag, instead of server's
+    hostname. Allows certificate validation to pass even when server's hostname does not
+    match the CN specified in server's certificate.
 
-    > This should only be used for connecting clients to emmy development server, for instance
-    where self-signed certificate is used, or when the CN in server's certificate is not resolvable.
-7. **Whether to use system's certificate pool**: flag *--syscertpool*. When present, the 
-values of `--cacert` and `--servername` will be ignored. 
-8. **Connection timeout**: flag *--timeout* (shorthand *-t*), indicating a timeout (in milliseconds)
- for establishing connection with emmy server. Client fails if connection cannot be established before
- the timeout. Defaults to *5000 milliseconds*.
+        > This should only be used for connecting clients to emmy development server, for instance
+        where self-signed certificate is used, or when the CN in server's certificate is not resolvable.
 
-Moreover, the *protocolSubcommand* corresponds to a concrete protocol that we want to demonstrate between emmy client and emmy server. You can list valid *protocolSubcommand* values by running 
+7.  **Whether to use system's certificate pool**: flag _--syscertpool_. When present, the
+    values of `--cacert` and `--servername` will be ignored.
+8.  **Connection timeout**: flag _--timeout_ (shorthand _-t_), indicating a timeout (in milliseconds)
+    for establishing connection with emmy server. Client fails if connection cannot be established before
+    the timeout. Defaults to _5000 milliseconds_.
+
+Moreover, the _protocolSubcommand_ corresponds to a concrete protocol that we want to demonstrate between emmy client and emmy server. You can list valid _protocolSubcommand_ values by running
 
 ```bash
-$ emmy client --help 
+$ emmy client --help
 ```
 
-To get more info on *protocolFlags* that the chosen *protocolCommand* supports, run `emmy client <protocolCommand> --help`, for instance
+To get more info on _protocolFlags_ that the chosen _protocolCommand_ supports, run `emmy client <protocolCommand> --help`, for instance
 
 ```bash
 $ emmy client pedersen --help
 ```
 
-and you will se additional flags that you can provide as input to bootstrap appropriate protocol. Usually, you can provide some sort of a secret value via the flag *--secret*, and the protocol variant to execute via the flag *--variant* (shorthand *-v*), denoting whether to execute sigma protocol, zero-knowledge proof or zero-knowledge proof of knowledge (`sigma|zkp|zkpok`, defaults to `sigma`).
+and you will se additional flags that you can provide as input to bootstrap appropriate protocol. Usually, you can provide some sort of a secret value via the flag _--secret_, and the protocol variant to execute via the flag _--variant_ (shorthand _-v_), denoting whether to execute sigma protocol, zero-knowledge proof or zero-knowledge proof of knowledge (`sigma|zkp|zkpok`, defaults to `sigma`).
 
 Below we give some examples that run emmy client in order to demonstrate Schnorr protocol:
-```
-$ emmy client schnorr #Runs sigma protocol with the default values
-$ emmy client --loglevel debug schnorr 
+
+```bash
+$ emmy client schnorr # runs sigma protocol with the default values
+$ emmy client --loglevel debug schnorr
 $ emmy client -l debug schnorr --variant zkp --secret 32432
 $ emmy client -l debug schnorr -v zkp --secret 32432
 ```
 
 Here are some more fun examples:
-```
+
+```bash
 $ emmy client --nclients 5 schnorr -v zkpok
 $ emmy client -n 5 schnorr -v zkpok # this one is equivalent to the one above
 $ emmy client -n 5 --concurrent schnorr -v zkpok
 ```
 
 And here is some example output of the `emmy client` command:
+
 ```
 $ emmy client --server localhost:7007 pedersen
 (1) GetConnection ▶ INFO  Getting the connection
@@ -414,32 +427,35 @@ $ emmy client --server localhost:7007 pedersen
 Lines 1-2 tell us about the procedure of initializing, and eventually, establishing a connection to emmy server at the given URI. Line 3 comes from the emmy CLI, and notifies us that the protocol client is about to start. Lines 4-9 indicate the communication taking place between the client and the server (e.g. here they are executing the chosen crypto protocol). The last line reports the total time required to execute the protocol - if we run several clients (either sequentially or concurrently), it prints the total time required for all the clients to finish.
 
 ## TLS support
+
 Communication channel between emmy clients and emmy server is secure, as it enforces the usage of TLS. TLS is used to encrypt communication and to ensure emmy server's authenticity.
 
 By default, the server will attempt to use the private key and certificate in `test/testdata` directory. The provided certificate is self-signed, and therefore the clients can use it as the CA certificate (e.g. certificate of the entity that issued server's certificate) which they have to provide in order to authenticate the server.
- >**Important note:** You should never use the private key and certificate that comes with this repository when running emmy in production. These are meant *for testing and development purposes only*.
+
+> **Important note:** You should never use the private key and certificate that comes with this repository when running emmy in production. These are meant _for testing and development purposes only_.
 
 In a real world setting, the client needs to keep a copy of the CA certificate which issued server's certificate. When the server presents its certificate to the client, the client uses CA's certificate to check the validity of server's certifiacate.
 
 To control keys and certificates used for TLS, emmy CLI programs use several flags. In addition to those already presented in this document, `emmy server` supports the following flags:
 
-* `--cert` which expects the path to server's certificate in PEM format, 
-* `--key` which expects the path to server's private key file.
+- `--cert` which expects the path to server's certificate in PEM format,
+- `--key` which expects the path to server's private key file.
 
 On the other hand, we can provide `emmy client` with the following flags:
-* `--cacert`, which expects the path to certificate of the CA that issued emmy server's certificate 
-(in PEM format). Again, if this flag is omitted, the certificate in `test/testdata` directory is used.
-* `--servername`, which instructs the client to skip validation of the server's hostname. In the 
-absence of this flag, client will always check whether the server's hostname matches 
-the common name (CN) specified in the server's certificate as a part of certificate validation. For 
-development purposes, hostname and server's CN will likely not match, and thus it is convenient to 
-provide a `--servername` flag with the value matching the CN specified in the server's certificate.
-* `--syscertpool`, which tells the client to look for the CA certificate in the host system's 
-certificate pool. If this flag is provided, the presence of `--cacert` or `--servername` flags 
-will be ignored. In addition, the CA certificate needs to be put in the system's default 
-certificate store location beforehand.
-  
-  To give you an example, let's try to run an emmy client against an instance of emmy server that uses the self-signed certificate shipped with this repository. The hostname in the certificate is *localhost*, but the server is deployed on a host other than localhost (for instance, *10.12.13.45*). When we try to contact the server withour the *--insecure* flag, here's what happens:
+
+- `--cacert`, which expects the path to certificate of the CA that issued emmy server's certificate
+  (in PEM format). Again, if this flag is omitted, the certificate in `test/testdata` directory is used.
+- `--servername`, which instructs the client to skip validation of the server's hostname. In the
+  absence of this flag, client will always check whether the server's hostname matches
+  the common name (CN) specified in the server's certificate as a part of certificate validation. For
+  development purposes, hostname and server's CN will likely not match, and thus it is convenient to
+  provide a `--servername` flag with the value matching the CN specified in the server's certificate.
+- `--syscertpool`, which tells the client to look for the CA certificate in the host system's
+  certificate pool. If this flag is provided, the presence of `--cacert` or `--servername` flags
+  will be ignored. In addition, the CA certificate needs to be put in the system's default
+  certificate store location beforehand.
+
+  To give you an example, let's try to run an emmy client against an instance of emmy server that uses the self-signed certificate shipped with this repository. The hostname in the certificate is _localhost_, but the server is deployed on a host other than localhost (for instance, _10.12.13.45_). When we try to contact the server withour the _--insecure_ flag, here's what happens:
 
   ```bash
   $ emmy client --server 10.12.13.45:7007 schnorr
@@ -448,9 +464,9 @@ certificate store location beforehand.
   Cannot connect to gRPC server: Could not connect to server 10.12.13.45:7007 (x509: cannot validate certificate for 10.12.13.45 because it doesnt contain any IP SANs)
   ```
 
-  Now let's include the *--insecure* flag, and the (insecure) connection to the server is now successfully established.
+  Now let's include the _--insecure_ flag, and the (insecure) connection to the server is now successfully established.
 
-  ```bash
+  ```
   $ emmy client --server 10.10.43.45:7007 --insecure schnorr
 
   2017/09/14 09:02:01 [client] 09:02:01.153 GetConnection ▶ INFO 001 Getting the connection
@@ -461,20 +477,21 @@ certificate store location beforehand.
   ```
 
 # Documentation
-* [A short overview of the theory emmy is based on](./docs/theory.md) 
-* [Developing emmy (draft)](./docs/develop.md) 
+
+- [A short overview of the theory emmy is based on](./docs/theory.md)
+- [Developing emmy (draft)](./docs/develop.md)
 
 # Roadmap
 
- * Improve the database layer supporting persistence of cryptographic material (credentials, pseudonyms, ...)
- * Refactor Camenisch-Lysyanskaya scheme (database records, challenge generation ... )
- * Additional proofs for Camenisch-Lysyanskaya scheme (range proof for attributes ... )
- * Revocation for Camenisch-Lysyanskaya scheme
- * Attribute types in Camenisch-Lysyanskaya scheme (string, int, date, enum)
- * Performance optimization (find bottlenecks and fix them)
- * Efficient attributes for anonymous credentials [15]
- * Camenisch-Lysyanskaya scheme based on pairings [14]
- * Fix Camenisch-Shoup verifiable encryption (it was implemented before many of the primitives were available)
+- Improve the database layer supporting persistence of cryptographic material (credentials, pseudonyms, ...)
+- Refactor Camenisch-Lysyanskaya scheme (database records, challenge generation ... )
+- Additional proofs for Camenisch-Lysyanskaya scheme (range proof for attributes ... )
+- Revocation for Camenisch-Lysyanskaya scheme
+- Attribute types in Camenisch-Lysyanskaya scheme (string, int, date, enum)
+- Performance optimization (find bottlenecks and fix them)
+- Efficient attributes for anonymous credentials [15]
+- Camenisch-Lysyanskaya scheme based on pairings [14]
+- Fix Camenisch-Shoup verifiable encryption (it was implemented before many of the primitives were available)
 
 # References
 
@@ -486,7 +503,7 @@ certificate store location beforehand.
 
 [4] A. Lysyanskaya, R. Rivest, A. Sahai, and S. Wolf. Pseudonym systems. In Selected Areas in Cryptography, vol. 1758 of LNCS. Springer Verlag, 1999.
 
-[5] C. P. Schnorr. Efficient Identification and Signatures for Smart Cards. In Crypto ’89, LNCS 435, pages 235–251. Springer-Verlag, Berlin, 1990. 
+[5] C. P. Schnorr. Efficient Identification and Signatures for Smart Cards. In Crypto ’89, LNCS 435, pages 235–251. Springer-Verlag, Berlin, 1990.
 
 [6] Goldwasser, Shafi, Silvio Micali, and Charles Rackoff. "The knowledge complexity of interactive proof systems." SIAM Journal on computing 18.1 (1989): 186-208.
 

--- a/docs/theory.md
+++ b/docs/theory.md
@@ -1,38 +1,31 @@
 # A quick review of the theory behind emmy
 
 ## What is a zero-knowlede proof (ZKP)?
-A zero-knowledge proof is protocol by which one party (prover) proves to another party (verifier) that 
-a given statement is true, without conveying any information apart from the fact that the statement 
-is indeed true.
+
+A zero-knowledge proof is protocol by which one party (prover) proves to another party (verifier) that a given statement is true, without conveying any information apart from the fact that the statement is indeed true.
 
 The required properties for zero knowledge proofs are:
 
- * _completeness_ - if the statement is true, the honest verifier (the verifier that follows the 
- protocol properly) will be convinced of this fact with overwhelming probability,
- * _soundness_ - no one who does not know the secret can convince the verifier with non-negligible 
- probability,
- * _zero knowledge_ - the proof does not leak any information.
- 
+- _completeness_ - if the statement is true, the honest verifier (the verifier that follows the
+  protocol properly) will be convinced of this fact with overwhelming probability,
+- _soundness_ - no one who does not know the secret can convince the verifier with non-negligible
+  probability,
+- _zero knowledge_ - the proof does not leak any information.
+
 A good resource on zero-knowledge proofs is [1].
 
 ## How can we build zero-knowledge proofs?
 
-Zero-knowledge proofs can be built upon **sigma protocols**. Sigma protocols are three-move protocols 
-(commitment, challenge and response) which have the following properties: _completeness_, 
-_special soundness_, and _special honest zero knowledge verifier_ (not going into definitions here, 
-please refer to [1]). An example of a sigma protocol is Schnorr protocol, where the prover proves 
-that he knows *w* such that *g<sup>w</sup> = h (mod p)* (proof of knowledge of a discrete logarithm):
+Zero-knowledge proofs can be built upon **sigma protocols**. Sigma protocols are three-move protocols
+(commitment, challenge and response) which have the following properties: _completeness_, _special soundness_, and _special honest zero knowledge verifier_ (not going into definitions here, please refer to [1]). An example of a sigma protocol is Schnorr protocol, where the prover proves that he knows $w$ such that $g^w \equiv h \pmod p$ (proof of knowledge of a discrete logarithm):
 
 ![schnorr protocol](./img/schnorr_protocol.png)
 
-We can turn sigma protocols like Schnorr protocol into **zero-knowledge proofs (ZKP)**. The key is 
-to enforce the verifier to behave honestly. This can be achieved by using **commitment scheme** [2]
-or by using one-bit challenges. Both techniques will be described below. 
+We can turn sigma protocols like Schnorr protocol into **zero-knowledge proofs (ZKP)**. The key is to enforce the verifier to behave honestly. This can be achieved by using **commitment scheme** [2] or by using one-bit challenges. Both techniques will be described below.
 
-How can a Schnorr protocol can be executed in emmy (given g, t, p how to prove the knowledge of s 
-where t = g<sup>s</sup> (mod p)):
+How a Schnorr protocol cam be executed in emmy, i.e. given $g, t, p$ how to prove the knowledge of $s$ where $t \equiv g^s \pmod p$:
 
-```
+```go
 prover := schnorr.NewProver(group, types.Sigma)
 verifier := schnorr.NewVerifier(group, types.Sigma)
 
@@ -47,109 +40,90 @@ verified := verifier.Verify(z, nil)
 The second parameter in both constructors specifies whether sigma protocol or ZKP should be executed
 (ZKP is sigma protocol extended with commitment scheme to enforce the verifier to behave honestly).
 
-Note that emmy provides a communication layer which enables execution of the protocols on two 
-remote devices. For brevity the examples here assume the execution of prover and verifier 
+Note that emmy provides a communication layer which enables execution of the protocols on two
+remote devices. For brevity the examples here assume the execution of prover and verifier
 on the same device.
 
 ### How can we prove that a protocol is sound
 
-That means - how can a prover prove the knowledge of a secret. This is done by showing that there 
-exists an algorithm which can extract the knowledge of a secret if the prover is used as a black-box 
-and can be rewinded to output the same first message in two protocol executions.
+That means - how can a prover prove the knowledge of a secret. This is done by showing that there exists an algorithm which can extract the knowledge of a secret if the prover is used as a black-box and can be rewinded to output the same first message in two protocol executions.
 
-Thus, in Schnorr protocol the transcripts of two protocol executions are (x = g<sup>r</sup> (mod p), c1, z1), 
-(x = g<sup>r</sup> (mod p), c2, z2). The parameters g, h, p are publicly known. Prover is proving 
-the knowledge of s such that:
+Thus, in Schnorr protocol the transcripts of two protocol executions are $x \equiv g^r \pmod p, c_1, z_1$ and
+$x \equiv g^r \pmod p, c_2, z_2$. The parameters $g, h, p$ are publicly known. Prover is proving the knowledge of $s$ such that:
 
-<code>
-g<sup>s</sup> = t (mod p)
-</code>
+$$
+g^s \equiv t \pmod p
+$$
 
 In the last step of both executions the extractor (playing the role of the verifier) verified that:
 
-<code>
-g<sup>z1</sup> = g<sup>r</sup> * (g<sup>s</sup>)<sup>c1</sup> = g<sup>r</sup> * t<sup>c1</sup> (mod p)
+$$
+g^{z_1} = g^r \times (g^s)^{c_1} = g^r \times t^{c_1} \pmod p
+$$
 
-g<sup>z2</sup> = g<sup>r</sup> * (g<sup>s</sup>)<sup>c2</sup> = g<sup>r</sup> * t<sup>c2</sup> (mod p)
-</code>
+$$
+g^{z_2} = g^r \times (g^s)^{c_2} = g^r \times t^{c_2} \pmod p
+$$
 
 Extractor divides both equations:
 
-<code>
-g<sup>z2-z1</sup> = t<sup>c2-c1</sup> (mod p)
-</code>
+$$
+g^{z_2-z_1} = t^{c_2-c_1} \pmod p
+$$
 
-Note that this is in Schnorr group which is cyclic with order q (see crypto/groups package).
+Note that this is in Schnorr group which is cyclic with order $q$ (see crypto/groups package).
 
-<code>
-g<sup>z2-z1</sup> = (g<sup>s</sup>)<sup>c2-c1</sup> = g<sup>s*(c2-c1)</sup> (mod p)
-</code>
+$$
+g^{z_2-z_1} = (g^s)^{c_2-c_1} = g^{s\times(c_2-c_1)} \pmod p
+$$
 
-Because Schnorr group is cyclic and its order is q:
+Because Schnorr group is cyclic and its order is $q$:
 
-<code>
-z2-z1 = s * (c2-c1) (mod q)
-</code>
+$$
+z_2-z_1 \equiv s \times (c_2-c_1) \pmod q
+$$
 
-Thus the extractor can compute s by computing inverse of (c2-c1) modulo q:
+Thus the extractor can compute s by computing inverse of $c_2-c_1$ modulo $q$:
 
-<code>
-s = (z2-z1) * (c2-c1)_inv (mod q)
-</code>
+$$
+s \equiv (z_2-z_1) \times (c_2-c_1)_\text{inv} \pmod q
+$$
 
-Note that this extractor works only if the order of the groups is known (q in Schnorr).
+Note that this extractor works only if the order of the groups is known ($q$ in Schnorr).
 
-The extractor can work for groups with hidden order if (c2-c1) divides (z2-z1) which is the case
-in Damgard-Fujisaki commitment scheme [3] or if one-bit challenges are used. More about such extractors
-will be provided below.
+The extractor can work for groups with hidden order if $c_2-c_1$ divides $z_2-z_1$ which is the case in Damgard-Fujisaki commitment scheme [3] or if one-bit challenges are used. More about such extractors will be provided below.
 
 ### How can we prove that a protocol is ZKP
 
-ZKP is proved by demonstrating that there exists a simulator which can simulate accepting 
-transcripts (by interacting with a verifier and without knowing a secret) which cannot be 
-distinguished from the transcripts between real prover and verifier.
+ZKP is proved by demonstrating that there exists a simulator which can simulate accepting transcripts (by interacting with a verifier and without knowing a secret) which cannot be distinguished from the transcripts between real prover and verifier.
 
-In Schnorr protocol the simulator first chooses a random challenge c and random z, then it
-outputs the transcript (g<sup>z</sup> * t<sup>-c</sup>, c, z). The transcript is accepting and cannot be
-distinguished from a real conversation between prover and verifier. However, this is true
-only when verifier is choosing the challenge randomly. In case verifier has some other
-method to choose challenges, we cannot simulate the transcripts. For this reason Schnorr
-protocol is honest-verifier zero-knowledge proof (HVZKP).
+In Schnorr protocol the simulator first chooses a random challenge c and random z, then it outputs the transcript $(g^z \times t^{-c}, c, z)$. The transcript is accepting and cannot be distinguished from a real conversation between prover and verifier. However, this is true only when verifier is choosing the challenge randomly. In case verifier has some other method to choose challenges, we cannot simulate the transcripts. For this reason Schnorr protocol is honest-verifier zero-knowledge proof (HVZKP).
 
-Once again one-bit challenges come to the rescue (but of course this makes protocol much less
-efficient because multiple iterations are needed). The simulator in this case does not need to
-rely on the verifier being honest - it chooses a challenge and continues only if the verifier
-chooses the same challenge (the verifier is used as black-box). If different challenge is chosen
-by a verifier, the simulator aborts this execution of the protocol and goes from the beginning.
-Note that the chances that the simulator and verifier chooses the same challenge are 50%, so the
-simulator can provide accepting transcripts (actually, any sufficiently small challenge space 
+Once again one-bit challenges come to the rescue (but of course this makes protocol much less efficient because multiple iterations are needed). The simulator in this case does not need to rely on the verifier being honest - it chooses a challenge and continues only if the verifier chooses the same challenge (the verifier is used as black-box). If different challenge is chosen by a verifier, the simulator aborts this execution of the protocol and goes from the beginning. Note that the chances that the simulator and verifier chooses the same challenge are 50%, so the simulator can provide accepting transcripts (actually, any sufficiently small challenge space
 would do).
 
-An alternative approach to make sigma protocol a ZKP is to use commitment scheme [2]. More about this 
-will be provided below.
+An alternative approach to make sigma protocol a ZKP is to use commitment scheme [2]. More about this will be provided below.
 
 ## Generalization of Schnorr protocol
 
-Schnorr protocol can be generalized to general groups and one-way homomorphisms (homomorphism in 
-Schnorr protocol being a function x -> g<sup>x</sup> (mod p)) to prove the knowledge of homomorphism
-preimage. Given a homomorphism f: G -> H and u from H, we want to prove that we know v from G
-such that f(v) = u.
+Schnorr protocol can be generalized to general groups and one-way homomorphisms (homomorphism in Schnorr protocol being a function $x \to g^x \pmod p$ to prove the knowledge of homomorphism
+preimage. Given a homomorphism $f: G \to H$ and $u$ from $H$, we want to prove that we know $v$ from $G$
+such that $f(v) = u$.
 
 The protocol goes:
 
- * P chooses r from H and sends m = f(r) to V.
- * V chooses random c and sends it to P.
- * P sends z = r * v<sup>c</sup> to V, who checks that f(z) = m * u<sup>e</sup>.
- 
-Note that this might be group with hidden order (like RSA, see `crypto/rsa` package), so one-bit
-challenges need to be used (making the protocol also ZKP).
+- P chooses $r$ from $H$ and sends $m = f(r)$ to V.
+- V chooses random $c$ and sends it to P.
+- P sends $z = r \times v^c$ to V, who checks that $f(z) = m \times u^e$.
+
+Note that this might be group with hidden order (like RSA, see `crypto/rsa` package), so one-bit challenges need to be used (making the protocol also ZKP).
 
 In emmy this protocol is available in `crypto/preimage` package and can be executed as:
 
-```
+```go
 prover := preimage.NewProver(homomorphism, H, v)
 verifier := preimage.NewVerifier(homomorphism, H, u)
-	
+
 for j := 0; j < iterations; j++ {
 	proofRandomData := prover.GetProofRandomData()
 	verifier.SetProofRandomData(proofRandomData)
@@ -163,14 +137,7 @@ for j := 0; j < iterations; j++ {
 return true
 ```
 
-This protocol is for example used by q-one-way commitment scheme [4] which uses the RSA group
-with hidden order, available in the same package (see `qoneway.Committer` and `qoneway.Receiver`). However, commitment 
-schemes in groups with hidden order with more efficient proofs have been developed which do not require 
-one-bit challenges, for example Damgard-Fujisaki [3].
-
-
-
-
+This protocol is for example used by q-one-way commitment scheme [4] which uses the RSA group with hidden order, available in the same package (see `qoneway.Committer` and `qoneway.Receiver`). However, commitment schemes in groups with hidden order with more efficient proofs have been developed which do not require one-bit challenges, for example Damgard-Fujisaki [3].
 
 ## References
 
@@ -181,4 +148,3 @@ one-bit challenges, for example Damgard-Fujisaki [3].
 [3] I. Damgard and E. Fujisaki. An integer commitment scheme based on groups with hidden order. http://eprint.iacr.org/2001, 2001.
 
 [4] Cramer, Ronald, and Ivan Damgård. "Zero-knowledge proofs for finite field arithmetic, or: Can zero-knowledge be for free?." Advances in Cryptology—CRYPTO'98. Springer Berlin/Heidelberg, 1998.
-


### PR DESCRIPTION
With the support of [math notation in markdown](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions) I thought it would be nice to use them for the README and theory.me which had a plenty of math expressions.

Also tidied up a bit of these markdown files while at it.